### PR TITLE
[iPoCap] Power capping 

### DIFF
--- a/devel-script/rapl_meter.py
+++ b/devel-script/rapl_meter.py
@@ -1,0 +1,93 @@
+import os
+import sys
+import struct
+import time
+import threading
+
+MAX_INTEGER = 0xffffffff
+
+current_time = lambda: int(round(time.time() * 1000000))
+
+class RaplMeter:
+
+	def __init__(self):		
+		self.energy_begin = 0
+		self.energy_end = 0
+		
+		self.time_begin = 0
+		self.time_end = 0
+		
+		self.ready = False
+		os.system("modprobe msr")
+		self.msr = self.open_msr()
+		self.energy_unit = self.get_energy_unit()
+
+		print("Energy counter unit: 1/(2^%d)J" % self.energy_unit)
+		print("rapl inited")
+	
+	def open_msr(self):
+		msr_path = "/dev/cpu/0/msr"
+		msr = os.open(msr_path, os.O_RDONLY)
+		self.ready = True
+		return msr
+
+	def read_msr(self, msr_no):
+		os.lseek(self.msr, msr_no, os.SEEK_SET)
+		val = struct.unpack('Q', os.read(self.msr, 8))[0]
+		return val
+
+	def close_msr(self):
+		os.close(self.msr)
+		self.ready = False
+
+	def energy_now(self):
+		val = self.read_msr(0x611)
+		return val & 0xffffffff
+
+	def get_energy_unit(self):
+		val = self.read_msr(0x606)
+		return (val & 0x1f00) >> 8
+
+	def is_ready(self):
+		return self.ready
+
+	def energy_diff(self):
+		diff = 0
+		if self.energy_end < self.energy_begin:	#overflow
+			diff = MAX_INTEGER - self.energy_begin
+			diff += self.energy_end
+		else:
+		    diff = self.energy_end - self.energy_begin
+		
+		return diff
+
+	def start(self):
+		self.time_begin = current_time()
+		self.energy_begin = self.energy_now()
+
+
+	def stop(self):
+		self.time_end = current_time()
+		self.energy_end = self.energy_now()
+
+	def get_power(self):
+		time_us = self.time_end - self.time_begin
+	
+		energy_uj = (self.energy_diff() * 1000000) >> self.energy_unit
+		power_w = float(energy_uj) / time_us
+		return time_us, energy_uj, power_w
+
+	def close(self):
+		self.close_msr()
+
+if __name__ == "__main__":
+	pmterm = RaplMeter()
+
+	for i in range(300):
+		pmterm.start()
+		time.sleep(1)
+		pmterm.stop()
+
+		print("%d\t%.2f" % (i, pmterm.get_power()[2]))
+		
+	pmterm.close()

--- a/kernel/ipocap.c
+++ b/kernel/ipocap.c
@@ -1,0 +1,5 @@
+#include "ipocap.h"
+
+QWORD g_power_limit_mw; // uj/ms
+QWORD g_power_base_mw;  // 98 uj/ms
+QWORD g_rapl_energy_unit;

--- a/kernel/ipocap.h
+++ b/kernel/ipocap.h
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __IPOCAP_H__
+#define __IPOCAP_H__
+
+#include "az_types.h"
+
+/* 
+ * Run Time Average Power Limiting (RAPL) Interface 
+ * referred to arch/x86/include/asm/msr-index.h of Linux kernel
+ */
+
+#define MSR_RAPL_POWER_UNIT		0x00000606
+
+#define MSR_PKG_POWER_LIMIT		0x00000610
+#define MSR_PKG_ENERGY_STATUS	0x00000611
+#define MSR_PKG_PERF_STATUS		0x00000613
+#define MSR_PKG_POWER_INFO		0x00000614
+
+#define MSR_DRAM_POWER_LIMIT	0x00000618
+#define MSR_DRAM_ENERGY_STATUS	0x00000619
+#define MSR_DRAM_PERF_STATUS	0x0000061b
+#define MSR_DRAM_POWER_INFO		0x0000061c
+
+#define MSR_PP0_POWER_LIMIT		0x00000638
+#define MSR_PP0_ENERGY_STATUS	0x00000639
+#define MSR_PP0_POLICY			0x0000063a
+#define MSR_PP0_PERF_STATUS		0x0000063b
+
+#define MSR_PP1_POWER_LIMIT		0x00000640
+#define MSR_PP1_ENERGY_STATUS	0x00000641
+#define MSR_PP1_POLICY			0x00000642
+
+extern QWORD g_power_limit_mw;
+extern QWORD g_power_base_mw;
+extern QWORD g_rapl_energy_unit;
+
+#define TSC_KHZ 1496534 //this value is for KNL, add calibration code
+#define tsc_to_ms(tsc) 	(( tsc )/TSC_KHZ)
+
+static inline QWORD __rdtsc(void){
+	unsigned long low, high;
+
+	asm volatile("rdtsc" : "=a" (low), "=d" (high));
+
+	return (QWORD) ((low) | (high) << 32);
+}
+
+static inline DWORD read_energy_counter(void){
+    unsigned long low, high;
+
+	asm volatile("rdmsr" : "=a" (low), "=d" (high) : "c" (MSR_PKG_ENERGY_STATUS));
+
+	return (DWORD) low;
+}
+
+/*
+ * Energy Status Units (bits 12:8 of MSR_RAPL_POWER_UNIT Register)
+ * 1 counter = 1/2^ESU Joule
+ */
+static inline unsigned int read_energy_unit(void){
+    unsigned long low, high;
+
+    asm volatile("rdmsr" : "=a" (low), "=d" (high) : "c" (MSR_RAPL_POWER_UNIT));
+
+	return (unsigned int) (low & 0x1f00) >> 8;
+}
+
+static inline QWORD rapl_energy_to_uj(QWORD counter){
+	unsigned int energy_unit = g_rapl_energy_unit;
+	return (counter * 1000000) >> energy_unit;
+}
+
+/*
+ * referred to arch/x86/include/asm/mwait.h of Linux kernel
+ */
+
+#define MWAIT_ECX_INTERRUPT_BREAK	0x1
+#define MWAITX_ECX_TIMER_ENABLE		0x1
+#define MWAITX_DISABLE_CSTATES		0xf
+
+struct cpuidle_state {
+	unsigned int	flags;
+	unsigned int	exit_latency; /* in US */
+	unsigned int	target_residency; /* in US */
+};
+
+static inline void __monitor(const void *eax, unsigned long ecx,
+			     unsigned long edx)
+{
+	/* "monitor %eax, %ecx, %edx;" */
+	asm volatile(".byte 0x0f, 0x01, 0xc8;"
+		     :: "a" (eax), "c" (ecx), "d"(edx));
+}
+
+static inline void __mwait(unsigned long eax, unsigned long ecx)
+{
+	/* "mwait %eax, %ecx;" */
+	asm volatile(".byte 0x0f, 0x01, 0xc9;"
+		     :: "a" (eax), "c" (ecx));
+}
+
+
+#endif

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -19,6 +19,7 @@
 #include "memory.h"
 #include "timer.h"
 #include "stat.h"
+#include "ipocap.h"
 
 static void main_for_ap(void);
 BOOL start_ap(void);
@@ -63,6 +64,9 @@ void Main(int boot_mode)
   g_memory_start = (*(QWORD*) (CONFIG_MEM_START + CONFIG_PAGE_OFFSET)) << 30;
   g_memory_end = (*(QWORD*) (CONFIG_MEM_END + CONFIG_PAGE_OFFSET)) << 30;
   g_shared_memory = ((QWORD) (UNIKERNEL_START-SHARED_MEMORY_SIZE)) << 30;
+
+  g_power_base_mw = 98 * 1000; // 98 uj/ms
+  g_rapl_energy_unit = (1000000 >> read_energy_unit()); // uj/counter
 
   if (boot_mode == 0) { // AP mode
     while(g_ap_ready == 0)

--- a/kernel/stat.c
+++ b/kernel/stat.c
@@ -18,6 +18,7 @@ static spinlock_t stat_lock;
 void stat_init(void)
 {
   g_stat_area = (STAT_AREA *) (CONFIG_SHARED_MEMORY + STAT_START_OFFSET); 
+  g_stat_area->plimit = 0;
 }
 
 /**
@@ -65,4 +66,8 @@ void set_cpu_load(int pid, QWORD core_load)
   g_stat_area->core_load[pid] = core_load;
 
   spinlock_unlock(&stat_lock);
+}
+
+inline int get_plimit(void){
+  return g_stat_area->plimit * 1000; //mw
 }

--- a/kernel/stat.h
+++ b/kernel/stat.h
@@ -17,6 +17,7 @@ typedef struct {
 } Unikernel;
 
 typedef struct {
+  int plimit;                         // power limit (read-write).
   int core_used[MAX_CORE];            // core allocation info.
   int core_load[MAX_CORE];            // core load info.
   int memory_used[MAX_MEMORY];        // memory allocation info.
@@ -30,5 +31,5 @@ void set_mem_info(QWORD mem_size);
 void set_cpu_num(int core_num);
 void set_cpu_load(int pid, QWORD core_load);
 void get_cpu_numm();
-
+int get_plimit(void);
 #endif  /* __STAT_H__ */

--- a/sideloader/lk/cmds.h
+++ b/sideloader/lk/cmds.h
@@ -22,6 +22,7 @@
 #define LK_CMD_THREAD           0x54
 #define LK_CMD_CONSOLE          0x55
 #define LK_CMD_LOG              0x56
+#define LK_CMD_IPOCAP           0x57
 
 // init state
 #define INIT_IA32E_START_STAT               0x01

--- a/sideloader/lk/lkernel.c
+++ b/sideloader/lk/lkernel.c
@@ -471,6 +471,16 @@ static long lk_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 
     printk (KERN_INFO "STAT copied\n");
     break;
+    
+  case LK_CMD_IPOCAP:
+  {
+    retu = copy_from_user(g_stat_addr, (const void __user *) arg, sizeof(long));
+    if (retu) {
+      printk (KERN_INFO "LK_CMD_IPOCAP: copy_from_user error\n");
+      return -EINVAL;
+    }
+  }
+    break;
 
   case LK_CMD_THREAD:
   {

--- a/sideloader/lk/stat.h
+++ b/sideloader/lk/stat.h
@@ -1,6 +1,7 @@
 #ifndef __STAT_H__
 #define __STAT_H__
 
+#include "arch.h"
 #include "cmds.h"
 
 typedef struct {
@@ -15,6 +16,7 @@ typedef struct {
 } Unikernel;
 
 typedef struct {
+  int plimit;                         // power limit (read-write).
   int core_used[MAX_CORE];            // core allocation info.
   int core_load[MAX_CORE];            // core load info.
   int memory_used[MAX_MEMORY];        // memory allocation info.

--- a/sideloader/utils/ipocap_limit_set.c
+++ b/sideloader/utils/ipocap_limit_set.c
@@ -1,0 +1,36 @@
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../lk/stat.h"
+
+int main(int argc, char *argv[])
+{
+  int fd = -1;
+  int ret = 0;
+  int plimit;
+
+  if (argc < 2) {
+    printf("ipocap_limit_set [power_limit(w)]\n");
+    return -1;
+  }
+
+  plimit = atoi(argv[1]);
+
+  fd = open("/dev/lk", O_RDONLY);
+
+  if (fd < 0) {
+    printf("/dev/lk open error\n");
+    return -1;
+  }
+
+
+  ret = ioctl(fd, LK_CMD_IPOCAP, &plimit);
+  if ( ret != 0 ) return -1 ;
+
+  close(fd);
+
+  return 0;
+}


### PR DESCRIPTION
I added power capping functionality to Azalea.
You can easily set or change the power limit using 'sideloader/utils/ipocap_limit_set'.
When the power consumption of the system exceeds the configured power limit, the thread scheduler with iPoCap injects idle to reduce the power consumption.