### PR TITLE
Reduce booting time by modifing thread and free memory initialization

### DIFF
--- a/kernel/memory.c
+++ b/kernel/memory.c
@@ -44,8 +44,7 @@ void free_mem_init(void)
   // Initialize the block list index areas to 0xFF
   g_free_memory.block_index = (BYTE*) free_mem_start;
 
-  for (i=0; i<g_free_memory.smallest_block; i++)
-    g_free_memory.block_index[i] = 0xFF;
+  lk_memset(g_free_memory.block_index, 0xFF, g_free_memory.smallest_block * sizeof(BYTE));
 
   // the base address of the bitmap
   g_free_memory.bitmap = (BITMAP*) (free_mem_start + (sizeof(BYTE) * g_free_memory.smallest_block));

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -91,7 +91,7 @@ void sched_init(void)
 void thread_init(void)
 {
   int i = 0;
-  TCB *tcb = NULL;
+  void *t_tcb = NULL;
 
   thread_list_init(&g_global_tcb_list);
 
@@ -101,12 +101,16 @@ void thread_init(void)
     g_running_thread_list[i] = NULL;
   }
 
+  t_tcb = az_alloc(PAGE_SIZE_4K*CONFIG_NUM_THREAD);
+  if(t_tcb == NULL)
+    debug_halt((char *) __func__, __LINE__);
+
   // Initialize TCBs
   for (i = 0; i < CONFIG_NUM_THREAD; i++) {
-    tcb = (TCB *) az_alloc(PAGE_SIZE_4K);
-    if(tcb == NULL)
-      debug_halt((char *) __func__, __LINE__);
+    TCB *tcb;
+    void *tcb_temp = t_tcb + (PAGE_SIZE_4K * i);
 
+    tcb = (TCB *) tcb_temp;
     tcb->state = THREAD_STATE_NOTALLOC;
     tcb->id = MAX_PROCESSOR_COUNT + i;
     tcb->gen = 0;


### PR DESCRIPTION
Fixed #104 
- Changed alloc to run only once in thread initialization.
- Change the for-loop to memset when free memory is initialized.