### PR TITLE
Modify unikernel memory mapping method from ioremap to mmap to fix slow IO perf. 

### DIFF
--- a/kernel/console/console_function.c
+++ b/kernel/console/console_function.c
@@ -23,9 +23,9 @@ extern QWORD *g_console_magic;
  * @return none
  */
 int cs_boot_msg_print(int yloc) {
-int x = 0, y = 0;
-char *screen = NULL;
-char line[CONSOLE_WIDTH+3];
+  int x = 0, y = 0;
+  char *screen = NULL;
+  char line[CONSOLE_WIDTH+1] = {0, };
 
   if(g_console_proxy_flag == FALSE)
     return (-1);
@@ -35,15 +35,11 @@ char line[CONSOLE_WIDTH+3];
     for (x = 0; x < CONSOLE_WIDTH; x++) {
       line[x] = *(screen + y*CONSOLE_WIDTH + x);
     }
-    line[CONSOLE_WIDTH] = '\n';
-    line[CONSOLE_WIDTH+1] = '\r';
-    line[CONSOLE_WIDTH+2] = '\0';
+    lk_sprintf(line, "%s\n", line);
     cs_write(1, line, lk_strlen(line));
   }
-
   return (0);
 }
-
 
 /**
  * @brief console write call
@@ -54,17 +50,17 @@ char line[CONSOLE_WIDTH+3];
  */
 ssize_t cs_write(int fd, void *buf, size_t count)
 {
-channel_t *ch = NULL;
-struct circular_queue *icq = NULL;
-struct circular_queue *ocq = NULL;
+  channel_t *ch = NULL;
+  struct circular_queue *icq = NULL;
+  struct circular_queue *ocq = NULL;
 
-TCB *current = NULL;
-QWORD mytid = -1;
+  TCB *current = NULL;
+  QWORD mytid = -1;
 
-ssize_t ssret = 0;
+  ssize_t ssret = 0;
 
-struct iovec iov[MAX_IOV_NUM];
-int iovcnt = 0;
+  struct iovec iov[MAX_IOV_NUM];
+  int iovcnt = 0;
 
   if(g_console_proxy_flag == FALSE)
     return (-1);
@@ -99,21 +95,21 @@ int iovcnt = 0;
  */
 int cs_printf(const char *parameter, ...)
 {
-channel_t *ch = NULL;
-struct circular_queue *icq = NULL;
-struct circular_queue *ocq = NULL;
+  channel_t *ch = NULL;
+  struct circular_queue *icq = NULL;
+  struct circular_queue *ocq = NULL;
 
-struct iovec iov[MAX_IOV_NUM];
-int iovcnt = 0;
+  struct iovec iov[MAX_IOV_NUM];
+  int iovcnt = 0;
 
-TCB *current = NULL;
-QWORD mytid = -1;
+  TCB *current = NULL;
+  QWORD mytid = -1;
 
-int iret = 0;
+  int iret = 0;
 
-va_list ap;
-char buf[1024];
-int len = 0;
+  va_list ap;
+  char buf[1024];
+  int len = 0;
 
   if(g_console_proxy_flag == FALSE)
     return (-1);
@@ -145,7 +141,6 @@ int len = 0;
   return (iret);
 }
 
-
 /**
  * @brief console print call
  * @param buf buffer
@@ -153,18 +148,18 @@ int len = 0;
  */
 int cs_puts(void *buf)
 {
-channel_t *ch = NULL;
-struct circular_queue *icq = NULL;
-struct circular_queue *ocq = NULL;
+  channel_t *ch = NULL;
+  struct circular_queue *icq = NULL;
+  struct circular_queue *ocq = NULL;
 
-TCB *current = NULL;
-QWORD mytid = -1;
+  TCB *current = NULL;
+  QWORD mytid = -1;
 
-size_t len = 0;
-int iret = 0;
+  size_t len = 0;
+  int iret = 0;
 
-struct iovec iov[MAX_IOV_NUM];
-int iovcnt = 0;
+  struct iovec iov[MAX_IOV_NUM];
+  int iovcnt = 0;
 
   if(g_console_proxy_flag == FALSE)
     return (-1);
@@ -196,19 +191,19 @@ int iovcnt = 0;
 
 /**
  * @brief console exit call
- * @param 
+ * @param none 
  * @return success (0), fail (-1)
  */
 int cs_exit(void)
 {
-channel_t *ch = NULL;
-struct circular_queue *icq = NULL;
-struct circular_queue *ocq = NULL;
+  channel_t *ch = NULL;
+  struct circular_queue *icq = NULL;
+  struct circular_queue *ocq = NULL;
 
-TCB *current = NULL;
-QWORD mytid = -1;
+  TCB *current = NULL;
+  QWORD mytid = -1;
 
-int iret = 0;
+  int iret = 0;
 
   if(g_console_proxy_flag == FALSE)
     return (-1);

--- a/sideloader/lk/lkernel.c
+++ b/sideloader/lk/lkernel.c
@@ -280,7 +280,6 @@ static long lk_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
     }
     memset(g_log, 0, LOG_SIZE);
     printk (KERN_INFO "LK_PARAM: g_log ioremap success!!: %lx\n", (unsigned long) g_log);
-
   }
     break;
 
@@ -308,7 +307,10 @@ static long lk_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
   {
   // LK_LOADING: Copy image file into the memory separated into bootloader, kernel, and application
     int ukid;
-    char *addr = NULL, *bladdr = NULL, *lkbin = NULL;
+#if 0
+    char *addr = NULL;
+#endif
+    char *bladdr = NULL, *lkbin = NULL;
 
     // copy image file into the lkbin variable
     lkbin = vmalloc((g_total) * SECTOR);
@@ -371,6 +373,7 @@ static long lk_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
     printk(KERN_INFO "LK_LOADING: MEMORY_START: %d GB, MEMORY_END: %d GB\n", (int) memory_start, (int) memory_end);
     printk(KERN_INFO "LK_LOADING: g_pml_addr %lx, apic_addr %lx\n", (unsigned long) g_pml_addr, (unsigned long) APIC_DEFAULT_PHYS_BASE);
 
+#if 0
     // Kernel
     addr = ioremap_nocache(memory_start_addr + KERNEL_ADDR, (g_total - g_kernel32) * SECTOR);
 
@@ -404,6 +407,8 @@ static long lk_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
            (g_kernel32+g_kernel64) * SECTOR, (g_total - g_kernel32 - g_kernel64) * SECTOR, addr);
 
     iounmap(addr);
+#endif 
+
     vfree(lkbin);
   }
     break;
@@ -659,6 +664,7 @@ static int lk_mmap(struct file *filp, struct vm_area_struct *vma)
   size_t vma_size = vma->vm_end - vma->vm_start;
   unsigned long long offset = vma->vm_pgoff << PAGE_SHIFT;
 
+#if 0
   vma->vm_flags |= VM_IO; // 
   vma->vm_flags |= (VM_DONTEXPAND | VM_DONTDUMP);
 
@@ -666,6 +672,8 @@ static int lk_mmap(struct file *filp, struct vm_area_struct *vma)
 
   vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot); 
   printk(KERN_INFO "off=%llx\n", (unsigned long long) vma->vm_pgoff); 
+#endif
+
   remap_pfn_range(vma, vma->vm_start, offset >> PAGE_SHIFT, vma_size, vma->vm_page_prot); 
 
   printk("2. remap start : %llx, off: %llx\n", (u64) vma->vm_start, (u64) vma->vm_pgoff);
@@ -709,7 +717,8 @@ void lk_exit(void)
 {
   // TODO
   __free_pages(g_ipcs_page, get_order(PAGE_SIZE * REMOTE_PAGE_MEMORY_SIZE));
-  iounmap((void *) g_boot_addr);
+  iounmap((void *) g_va_boot_addr);
+  iounmap((void *) g_vcon);
   iounmap((void *) g_stat);
   iounmap((void *) g_shell_storage);
   iounmap((void *) g_log);

--- a/sideloader/lk/lkernel.h
+++ b/sideloader/lk/lkernel.h
@@ -2,12 +2,13 @@
 #define __LKERNEL_H__
 
 #define PAGE_4K             (0x1000)
-#define CONFIG_PARAM_NUM    5
+#define CONFIG_PARAM_NUM    7
 #define SECTOR				512
 
-#define LK_IMG_SIZE			0
-#define LK_LOADING			1
-#define LK_PARAM			4
+#define AZ_PARAM            10
+#define AZ_LOADING          11
+#define AZ_GET_MEM_ADDR     12
+#define AZ_PRINT_MSG        13
 
 #define CPU_ON				100
 #define CPU_OFF				110

--- a/sideloader/utils/lkload.c
+++ b/sideloader/utils/lkload.c
@@ -10,6 +10,16 @@
 #include <unistd.h>
 
 #include "../lk/lkernel.h"
+#include "arch.h"
+
+#define RED   "\x1B[31m"
+#define GRN   "\x1B[32m"
+#define YEL   "\x1B[33m"
+#define BLU   "\x1B[34m"
+#define MAG   "\x1B[35m"
+#define CYN   "\x1B[36m"
+#define WHT   "\x1B[37m"
+#define RESET "\x1B[0m"
 
 /**
  * Load the disk image to the unikernel with parameters
@@ -23,9 +33,19 @@ int main(int argc, char *argv[] )
   int fd = 0, fd1 = 0;
   int ret = 0;
   char *buf = NULL;
+  char *addr = NULL ;
   unsigned short param[CONFIG_PARAM_NUM] = {0, };
   unsigned int filesize = 0, readbytes  = 0;
   int i = 0;
+
+  unsigned short g_kernel32 = 0 ;
+  unsigned short g_kernel64 = 0 ;
+  unsigned short g_uapp = 0;
+  unsigned short g_total = 0 ;
+
+  short start_index = 0 ; 
+  unsigned int core_start = 0, core_end = 0 ;
+  unsigned long memory_start, memory_end, memory_start_addr, memory_shared_addr;
 
   if (argc < 7)	{
     printf("[usage] :lkload <disk.img> [index] [CPU] [MEMORY]\n"); 
@@ -39,7 +59,7 @@ int main(int argc, char *argv[] )
   fd1 = open(argv[1], O_RDONLY);
 
   if (fd1 < 0) {
-    printf("[%s] open failed\n", argv[1]);
+    printf(RED "LK_LOAD: " RESET "[%s] open failed\n", argv[1]);
     return -1;
   }
 
@@ -48,7 +68,7 @@ int main(int argc, char *argv[] )
   buf = malloc(filesize);
 
   if (buf == NULL) {
-    printf("memory allocation failed \n");
+    printf(RED "LK_LOAD: " RESET "memory allocation failed \n");
     close(fd1);
     return -1;
   }
@@ -58,17 +78,42 @@ int main(int argc, char *argv[] )
   readbytes = read(fd1, buf, filesize);
 
   if (readbytes != filesize) {
-    printf("read failed from disk.img\n");
+    printf(RED "LK_LOAD: " RESET "read failed from disk.img\n");
     free(buf);
     close(fd1);
     return -1;
   }
 
   close(fd1);
-  printf("%s opened... [FILESIZE : %d]\n", argv[1], filesize);
+  printf(BLU "LK_LOAD: " RESET "%s opened... [FILESIZE: %d]\n", argv[1], filesize);
+
+  start_index = atoi(argv[2]) ;
+  core_start = (atoi(argv[3]) == 0) ? CPUS_PER_NODE : atoi(argv[3]);
+  core_end = 0;    // deprecated
+  if (start_index != -1 ) {
+     memory_start = UNIKERNEL_START + (start_index * MEMORYS_PER_NODE);   // memory_start
+     memory_end = UNIKERNEL_START + ((start_index+1) * MEMORYS_PER_NODE);  // memory_end
+  } else {
+     memory_start = atoi(argv[5]) ;
+     memory_end = atoi(argv[6]) ;
+  }
+
+  memory_start_addr = memory_start << 30 ;
+  memory_shared_addr = ((unsigned long) (UNIKERNEL_START-SHARED_MEMORY_SIZE)) << 30;
+
+  printf(BLU "LK_LOAD: " RESET "CPU list: %d / Memory: %ldG~%ldG\n", atoi(argv[3]),memory_start, memory_end) ;
+
+  g_total = *((unsigned short *)(buf+TOTAL_COUNT_OFFSET+0)) ;
+  g_kernel32 = *((unsigned short *)(buf+TOTAL_COUNT_OFFSET+2)) ;
+  g_kernel64 = *((unsigned short *)(buf+TOTAL_COUNT_OFFSET+4)) ;
+  g_uapp = *((unsigned short *)(buf+TOTAL_COUNT_OFFSET+6)) ;
+
+  printf(BLU "LK_LOAD: " RESET "total: %d [bootloader:%d / kernel64:%d / uthread:%d]\n",
+           g_total, g_kernel32, g_kernel64, g_total - g_kernel32 - g_kernel64);
+
 
   // Open the lk module
-  fd = open("/dev/lk", O_RDONLY);
+  fd = open("/dev/lk", O_RDWR);
 
   if (fd < 0) {
     printf(" /dev/lk open error\n");
@@ -103,10 +148,41 @@ int main(int argc, char *argv[] )
     free(buf);
     return -1;
   }
-  printf("kernel image loading done...\n");
+
+  printf(BLU "LK_LOAD: " RESET "copy trampoline and make inital pagetable\n") ;
+
+  addr = mmap(NULL, (g_total-g_kernel32)*SECTOR , PROT_WRITE | PROT_READ, MAP_SHARED, fd, memory_start_addr + KERNEL_ADDR );
+ 
+  if ( addr == NULL )
+  {
+	  printf(RED "LK_LOAD: " RESET "failed to load kernel-lib\n") ;
+          close(fd) ;
+	  free(buf) ; 
+	  return -1 ;
+
+  }
+  memcpy(addr, buf + (g_kernel32 * SECTOR) , g_kernel64*SECTOR ) ;
+  munmap(addr, g_kernel64*SECTOR) ;
+
+  addr =  mmap(NULL, (g_total-g_kernel32-g_kernel64)*SECTOR, PROT_WRITE | PROT_READ, MAP_SHARED, fd, memory_start_addr + APP_ADDR );
+
+  if (addr == NULL )
+  {	
+	  printf(RED "LK_LOAD: " RESET "failed to load apps\n") ;
+	  close(fd) ;
+	  free(buf) ;
+	  return -1 ;
+
+  }
+
+  memcpy(addr, buf+(g_kernel32*SECTOR)+(g_kernel64 * SECTOR), (g_total-g_kernel32-g_kernel64) * SECTOR);
+
+  printf(BLU "LK_LOAD: " RESET "Application copied from [%d] size:[%d] bytes to %p\n",
+           (g_kernel32+g_kernel64) * SECTOR, (g_total-g_kernel32-g_kernel64) * SECTOR, addr );
+  
+  munmap(addr, (g_total - g_kernel32 - g_kernel64) * SECTOR ) ;
 
   close(fd);
-
   free(buf);
 
   return 0;


### PR DESCRIPTION
Fixed #106 
Fixed #103

  - load bootloader in lkernel.c by using ioremap
  - load kernel and applicaiton in lkload.c by using mmap
  - implement additional required functions.
  - Simply design of resource manager
  - Resolved vcon initialize problem