### PR TITLE
Add thread pool functions in offload proxy and schedule_to() function in kernel 

### DIFF
--- a/kernel/offload/offload_channel.h
+++ b/kernel/offload/offload_channel.h
@@ -1,6 +1,8 @@
 #ifndef __OFFLOAD_CHANNEL_H__
 #define __OFFLOAD_CHANNEL_H__
 
+#include <sys/lock.h>
+
 #include "mutex.h"
 
 #define CQ_ELE_PAGE_NUM (2)             // 2
@@ -19,8 +21,10 @@ struct circular_queue {
   int head;
   int tail;
   unsigned long size;
-  char padding[64] __attribute__((aligned(L_CACHE_LINE_SIZE))); 
+  char padding1[64] __attribute__((aligned(L_CACHE_LINE_SIZE))); 
   ticket_mutex_t lock __attribute__((aligned(L_CACHE_LINE_SIZE)));
+  char padding2[64] __attribute__((aligned(L_CACHE_LINE_SIZE)));
+  spinlock_t slock __attribute__((aligned(L_CACHE_LINE_SIZE)));
 
   cq_element data[0] __attribute__((aligned(4096)));
 };

--- a/kernel/offload/offload_message.c
+++ b/kernel/offload/offload_message.c
@@ -1,7 +1,6 @@
 #include "console.h"
 #include "offload_message.h"
-
-#define OFFLOAD_LOCK_ENABLE
+#include "thread.h"
 
 extern int g_ukid;
 
@@ -18,42 +17,63 @@ extern int g_ukid;
  * @param param6 6th parameter
  * return none
  */
-void send_offload_message(struct circular_queue *ocq, int tid, int offload_function_type, QWORD param1, QWORD param2, QWORD param3, QWORD param4, QWORD param5, QWORD param6) 
+void send_offload_message(struct circular_queue *ocq, int tid, int offload_function_type, QWORD param1, QWORD param2, QWORD param3, QWORD param4, QWORD param5, QWORD param6)
 {
 cq_element *ce = NULL;
 io_packet_t *opkt = NULL;
 int offload_tid = 0;
+int check_count = 0;
 
-#ifdef OFFLOAD_LOCK_ENABLE
-  mutex_lock(&ocq->lock);
-  while (cq_free_space(ocq) == 0) {
-    ;
+send_retry:
+
+  //mutex_lock(&ocq->lock);
+  spinlock_lock(&ocq->slock);
+
+check_ocq:
+
+  if(cq_free_space(ocq) != 0) {
+
+    offload_tid = g_ukid * 10000 + tid;
+
+    ce = (cq_element *) (ocq->data + ocq->head);
+    opkt = (io_packet_t *) ce;
+
+    opkt->magic = OFFLOAD_MAGIC;
+    opkt->tid = offload_tid;
+    opkt->io_function_type = offload_function_type;
+    opkt->param1 = param1;
+    opkt->param2 = param2;
+    opkt->param3 = param3;
+    opkt->param4 = param4;
+    opkt->param5 = param5;
+    opkt->param6 = param6;
+
+    ocq->head = (ocq->head + 1) % ocq->size;
+
+    mfence();
+    //mutex_unlock(&ocq->lock);
+    spinlock_unlock(&ocq->slock);
   }
-#else
-  while (cq_free_space(ocq) == 0);
-#endif
-  offload_tid = g_ukid * 10000 + tid;
+  else {
+    if(check_count < 1000) {
+      check_count++;
+      goto check_ocq;
+    }
 
-  // make packet header
-  ce = (cq_element *) (ocq->data + ocq->head);
-  opkt = (io_packet_t *) ce;
+    mfence();
+    spinlock_unlock(&ocq->slock);
+    //mutex_unlock(&ocq->lock);
 
-  opkt->magic = OFFLOAD_MAGIC;
-  opkt->tid = offload_tid;
-  opkt->io_function_type = offload_function_type;
-  opkt->param1 = param1;
-  opkt->param2 = param2;
-  opkt->param3 = param3;
-  opkt->param4 = param4;
-  opkt->param5 = param5;
-  opkt->param6 = param6;
-
-  ocq->head = (ocq->head + 1) % ocq->size;
-
-#ifdef OFFLOAD_LOCK_ENABLE
-  mutex_unlock(&ocq->lock);
-#endif
+    get_current()->remaining_time_slice = 0;
+    schedule(THREAD_INTENTION_READY);
+    goto send_retry;
+  }
 }
+
+
+
+
+
 
 /**
  *@brief receive offload message
@@ -68,33 +88,50 @@ cq_element *ce = NULL;
 io_packet_t *ipkt = NULL;
 QWORD ret = 0;
 int offload_tid = 0;
+int check_count = 0;
 
-retry_receive_sys_message:
-#ifdef OFFLOAD_LOCK_ENABLE
-  mutex_lock(&icq->lock);
-  while (cq_avail_data(icq) == 0);
-#else
-  while (cq_avail_data(icq) == 0);
-#endif
-  offload_tid = g_ukid * 10000 + tid;
-  ce = (cq_element *) (icq->data + icq->tail);
-  ipkt= (io_packet_t *)(ce);
-  if((int) ipkt->tid == (int) offload_tid && (int) ipkt->io_function_type == (int) offload_function_type) {
-    ret = ipkt->ret;
-    icq->tail = (icq->tail + 1) % icq->size;
+receive_retry:
+    spinlock_lock(&icq->slock);
+    //mutex_lock(&icq->lock);
 
-#ifdef OFFLOAD_LOCK_ENABLE
-    mutex_unlock(&icq->lock);
-#endif
-  }
-  else {
-#ifdef OFFLOAD_LOCK_ENABLE
-    mutex_unlock(&icq->lock);
-#endif
-    //schedule(THREAD_INTENTION_READY);
-    goto retry_receive_sys_message;
-  }
+    check_count = 0;
+check_icq:
+
+  if (cq_avail_data(icq)) {
+    ce = (icq->data + icq->tail);
+    ipkt= (io_packet_t *)(ce);
+    offload_tid = g_ukid * 10000 + tid;
+    if((int) ipkt->tid == (int) offload_tid) {
+      ret = ipkt->ret;
+      icq->tail = (icq->tail + 1) % icq->size;
+
+      mfence();
+      spinlock_unlock(&icq->slock);
+      //mutex_unlock(&icq->lock);
+    }
+    else {
+      mfence();
+      spinlock_unlock(&icq->slock);
+      //mutex_unlock(&icq->lock);
+      schedule_to((int) (ipkt->tid - g_ukid * 10000), THREAD_INTENTION_READY);
+
+      goto receive_retry;
+    }
+  } else {
+
+    if(check_count < 1000) {
+      check_count++;
+      goto check_icq;
+    }
+    mfence();
+      spinlock_unlock(&icq->slock);
+      //mutex_unlock(&icq->lock);
+
+      get_current()->remaining_time_slice = 0;
+      schedule(THREAD_INTENTION_READY);
+
+      goto receive_retry;
+    }
 
   return ret;
 }
-

--- a/kernel/offload/offload_message.c
+++ b/kernel/offload/offload_message.c
@@ -71,10 +71,6 @@ check_ocq:
 }
 
 
-
-
-
-
 /**
  *@brief receive offload message
  *@param icq circular queue
@@ -123,15 +119,16 @@ check_icq:
       check_count++;
       goto check_icq;
     }
+
     mfence();
-      spinlock_unlock(&icq->slock);
-      //mutex_unlock(&icq->lock);
+    spinlock_unlock(&icq->slock);
+    //mutex_unlock(&icq->lock);
 
-      get_current()->remaining_time_slice = 0;
-      schedule(THREAD_INTENTION_READY);
+    get_current()->remaining_time_slice = 0;
+    schedule(THREAD_INTENTION_READY);
 
-      goto receive_retry;
-    }
+    goto receive_retry;
+  }
 
   return ret;
 }

--- a/kernel/signal.h
+++ b/kernel/signal.h
@@ -1,6 +1,8 @@
 #ifndef __SIGNAL_H__
 #define __SIGNAL_H__
 
+#include <sys/lock.h>
+
 #include "az_types.h"
 #include "list.h"
 #include "sync.h"

--- a/kernel/thread.h
+++ b/kernel/thread.h
@@ -61,7 +61,7 @@
 #define THREAD_DEFAULT_TIME_QUANTUM   THREAD_INFINITE_TIME_QUANTUM
 #define THREAD_DEFAULT_TIME_SLICE     (10)
 #define THREAD_IDLE_THREAD_TIME_SLICE (10)
-#define RUNNABLE_MAX			20
+#define RUNNABLE_MAX			100
 #endif
 
 #define THREAD_INIT_NAME	      (~0x0)
@@ -193,6 +193,7 @@ int __thread_exit(int tid);
 int thread_exit(TCB *tcb);
 int lk_app_exec(void *app_ptr);
 BOOL schedule(QWORD intention);
+BOOL schedule_to(int next_tid, QWORD intention);
 int thread_suspend(int tid);
 int thread_wake_up(int tid);
 

--- a/sideloader/offload_console/console_proxy.c
+++ b/sideloader/offload_console/console_proxy.c
@@ -94,30 +94,30 @@ void cmd(channel_t *cs)
   while (loop) {
     switch (getchar()) {
     // show queue status
-    case 'q':
-	ocq = cs->out_cq;
-	icq = cs->in_cq;
-        printf("queue state(%03d): ptu: h:%d t:%d utp: h:%d t:%d\n", start_index, ocq->head, ocq->tail, icq->head, icq->tail);
-      break;
-
-    // stop console_local_proxy which manages the channels on scif region
-    case 'x':
-      g_console_proxy_runnable = 0;
-      console_channel_info = ((unsigned long *) g_mmap_console_channels_info_va) + start_index;
-      *(console_channel_info) = (unsigned long) 0;
-      loop = 0;
-      break;
-
-    case '\n':
-      printf("> ");
-      fflush(stdout);
-      break;
-
-    default:
-      break;
+      case 'q':
+          ocq = cs->out_cq;
+          icq = cs->in_cq;
+          printf("queue state(%03d): ptu: h:%d t:%d utp: h:%d t:%d\n", start_index, ocq->head, ocq->tail, icq->head, icq->tail);
+        break;
+ 
+      // stop console_local_proxy which manages the channels on scif region
+      case 'x':
+        g_console_proxy_runnable = 0;
+        console_channel_info = ((unsigned long *) g_mmap_console_channels_info_va) + start_index;
+        *(console_channel_info) = (unsigned long) 0;
+        loop = 0;
+        break;
+ 
+      case '\n':
+        printf("> ");
+        fflush(stdout);
+        break;
+ 
+      default:
+        break;
     }
+    usleep(10);
   }
-  usleep(10);
 }
 
 

--- a/sideloader/offload_proxy/Makefile
+++ b/sideloader/offload_proxy/Makefile
@@ -16,7 +16,7 @@ CFLAGS = -Wall -D_GNU_SOURCE -O0 -g
 CC = gcc
 offload_local_proxy: offload_local_proxy.c
 
-	$(CC) $(CFLAGS) $(INCS) $< offload_channel.o offload_mmap.o offload_message.o offload_fio.o offload_network.o -lpthread -o $@
+	$(CC) $(CFLAGS) $(INCS) $< offload_channel.o offload_mmap.o offload_message.o offload_fio.o offload_network.o offload_thread_pool.o -lpthread -o $@
 
 prepare:
 	$(CC) $(CFLAGS) $(INCS) offload_channel.c -o offload_channel.o -c
@@ -24,6 +24,7 @@ prepare:
 	$(CC) $(CFLAGS) $(INCS) offload_message.c -o offload_message.o -c
 	$(CC) $(CFLAGS) $(INCS) offload_fio.c -o offload_fio.o -c
 	$(CC) $(CFLAGS) $(INCS) offload_network.c -o offload_network.o -c
+	$(CC) $(CFLAGS) $(INCS) offload_thread_pool.c -o offload_thread_pool.o -c
 
 all: prepare offload_local_proxy
 

--- a/sideloader/offload_proxy/atomic.h
+++ b/sideloader/offload_proxy/atomic.h
@@ -1,0 +1,117 @@
+#ifndef __ATOMIC_H__
+#define __ATOMIC_H__
+
+#define ATOMIC_INIT(i)  { (i) }
+
+#define	QWORD	unsigned long
+
+typedef struct {
+  int c;
+} atomic_t;
+
+typedef struct {
+  QWORD c;
+} atomic64_t;
+
+// Functions
+static inline int atomic_get(atomic_t *a)
+{
+  return a->c;
+}
+
+static inline void atomic_set(atomic_t *a, int v)
+{
+  a->c = v;
+}
+
+static inline void atomic_inc(atomic_t *a)
+{
+  asm volatile ("lock; incl %0":"+m" (a->c));
+}
+
+static inline int atomic_inc_return(atomic_t *a)
+{
+  asm volatile ("lock; incl %0":"+m" (a->c));
+
+  return a->c;
+}
+
+static inline void atomic_dec(atomic_t *a)
+{
+  asm volatile ("lock; decl %0":"+m" (a->c));
+}
+
+static inline int atomic_dec_and_test(atomic_t *a)
+{
+  char c;
+  asm volatile ("lock; decl %0; sete %1":"+m" (a->c), "=qm"(c):: "memory");
+  return c != 0;
+}
+
+static inline void atomic_and(int v, atomic_t *a)
+{
+  asm volatile ("lock; andl %1, %0":"+m" (a->c):"er"(v):"memory");
+}
+
+static inline void atomic_or(int v, atomic_t *a)
+{
+  asm volatile ("lock; orl %1, %0":"+m" (a->c):"er"(v):"memory");
+}
+
+static inline void atomic_xor(int v, atomic_t *a)
+{
+  asm volatile ("lock; xorl %1, %0":"+m" (a->c):"er"(v):"memory");
+}
+
+static inline int atomic_read(atomic_t *a)
+{
+  return a->c;
+}
+
+static inline QWORD atomic64_test_and_set(atomic64_t *a, QWORD ret)
+{
+  asm volatile ("xchgq %0, %1" : "=r"(ret) : "m"(a->c), "0"(ret) : "memory");
+
+  return ret;
+}
+
+static inline QWORD atomic64_add(atomic64_t *a, QWORD i)
+{
+  QWORD ret = i;
+  asm volatile("lock; xaddq %0, %1" : "+r"(i), "+m"(a->c) : : "memory", "cc");
+
+  return ret+i;
+}
+
+static inline QWORD atomic64_sub(atomic64_t *a, QWORD i)
+{
+  return atomic64_add(a, -i);
+}
+
+static inline QWORD atomic64_inc(atomic64_t *a)
+{
+  QWORD ret = 1;
+  asm volatile("lock; xaddq %0, %1" : "+r"(ret), "+m"(a->c) : : "memory", "cc");
+
+  return ++ret;
+}
+
+static inline QWORD atomic64_dec(atomic64_t *a)
+{
+  QWORD ret = -1;
+  asm volatile("lock; xaddq %0, %1" : "+r"(ret), "+m"(a->c) : : "memory", "cc");
+
+  return --ret;
+}
+
+static inline QWORD atomic64_read(atomic64_t *a)
+{
+  return a->c;
+}
+
+static inline void atomic64_set(atomic64_t *a, QWORD v) 
+{
+  atomic64_test_and_set(a, v);
+}
+
+#endif  /* __ATOMIC_H__ */

--- a/sideloader/offload_proxy/offload_channel.h
+++ b/sideloader/offload_proxy/offload_channel.h
@@ -1,6 +1,8 @@
 #ifndef __OFFLOAD_CHANNEL_H__
 #define __OFFLOAD_CHANNEL_H__
 
+#include <pthread.h>
+
 #include "offload_memory_config.h"
 
 #define	PAGE_SIZE_4K	(0x1000)
@@ -51,6 +53,10 @@ typedef struct channel_struct {
   int in_connected;
   struct circular_queue *in_cq;
   unsigned long in_cq_len;
+
+  char padding1[64] __attribute__((aligned(L_CACHE_LINE_SIZE)));
+  pthread_mutex_t mutex;
+  char padding2[64] __attribute__((aligned(L_CACHE_LINE_SIZE)));
 } channel_t;
 
 // Channel function

--- a/sideloader/offload_proxy/offload_fio.c
+++ b/sideloader/offload_proxy/offload_fio.c
@@ -13,6 +13,7 @@
 #include "offload_fio.h"
 #include "offload_message.h"
 #include "offload_mmap.h"
+#include "offload_thread_pool.h"
 
 //#define DEBUG
 
@@ -21,7 +22,7 @@
  * @param channel 
  * @return none
  */
-void sys_off_open(thread_job_t *job)
+void sys_off_open(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -36,9 +37,9 @@ void sys_off_open(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -74,7 +75,7 @@ void sys_off_open(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys_off_creat(thread_job_t *job)
+void sys_off_creat(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -88,9 +89,9 @@ void sys_off_creat(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -161,7 +162,7 @@ ssize_t do_sys_off_read_v(int fd, unsigned long iov_pa, int iovcnt)
  * @param channel 
  * @return none
  */
-void sys_off_read(thread_job_t *job)
+void sys_off_read(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -176,9 +177,9 @@ void sys_off_read(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -255,7 +256,7 @@ ssize_t do_sys_off_write_v(int fd, unsigned long iov_pa, int iovcnt)
  * @param channel 
  * @return none
  */
-void sys_off_write(thread_job_t *job)
+void sys_off_write(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -270,9 +271,9 @@ void sys_off_write(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -303,7 +304,7 @@ void sys_off_write(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys_off_close(thread_job_t *job)
+void sys_off_close(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -316,9 +317,9 @@ void sys_off_close(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -351,7 +352,7 @@ void sys_off_close(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys_off_lseek(thread_job_t *job)
+void sys_off_lseek(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -366,9 +367,9 @@ void sys_off_lseek(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -397,7 +398,7 @@ void sys_off_lseek(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys_off_link(thread_job_t *job)
+void sys_off_link(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -411,9 +412,9 @@ void sys_off_link(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -441,7 +442,7 @@ void sys_off_link(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys_off_unlink(thread_job_t *job)
+void sys_off_unlink(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -454,9 +455,9 @@ void sys_off_unlink(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -481,7 +482,7 @@ void sys_off_unlink(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys_off_stat(thread_job_t *job)
+void sys_off_stat(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -495,9 +496,9 @@ void sys_off_stat(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -523,7 +524,7 @@ void sys_off_stat(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys3_off_getcwd(thread_job_t *job)
+void sys3_off_getcwd(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -537,9 +538,9 @@ void sys3_off_getcwd(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -565,7 +566,7 @@ void sys3_off_getcwd(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys3_off_system(thread_job_t *job)
+void sys3_off_system(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -578,9 +579,9 @@ void sys3_off_system(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -605,7 +606,7 @@ void sys3_off_system(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys_off_chdir(thread_job_t *job)
+void sys_off_chdir(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -618,9 +619,9 @@ void sys_off_chdir(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -645,7 +646,7 @@ void sys_off_chdir(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys3_off_opendir(thread_job_t *job)
+void sys3_off_opendir(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -658,9 +659,9 @@ void sys3_off_opendir(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -686,7 +687,7 @@ void sys3_off_opendir(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys3_off_closedir(thread_job_t *job)
+void sys3_off_closedir(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -699,9 +700,9 @@ void sys3_off_closedir(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -726,7 +727,7 @@ void sys3_off_closedir(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys3_off_readdir(thread_job_t *job)
+void sys3_off_readdir(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -739,9 +740,9 @@ void sys3_off_readdir(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;
@@ -771,7 +772,7 @@ void sys3_off_readdir(thread_job_t *job)
  * @param channel 
  * @return none
  */
-void sys3_off_rewinddir(thread_job_t *job)
+void sys3_off_rewinddir(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -782,9 +783,9 @@ void sys3_off_rewinddir(thread_job_t *job)
   int  offload_function_type = 0;
 
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   tid = (int) in_pkt->tid;
   offload_function_type = (int) in_pkt->io_function_type;

--- a/sideloader/offload_proxy/offload_fio.h
+++ b/sideloader/offload_proxy/offload_fio.h
@@ -3,23 +3,24 @@
 
 #include "offload_channel.h"
 #include "offload_message.h"
+#include "offload_thread_pool.h"
 
-void sys_off_open(thread_job_t *job);
-void sys_off_creat(thread_job_t *job);
-void sys_off_read(thread_job_t *job);
-void sys_off_write(thread_job_t *job);
-void sys_off_lseek(thread_job_t *job);
-void sys_off_close(thread_job_t *job);
-void sys_off_link(thread_job_t *job);
-void sys_off_unlink(thread_job_t *job);
-void sys_off_stat(thread_job_t *job);
-void sys3_off_getcwd(thread_job_t *job);
-void sys3_off_system(thread_job_t *job);
-void sys_off_chdir(thread_job_t *job);
-void sys3_off_opendir(thread_job_t *job);
-void sys3_off_closedir(thread_job_t *job);
-void sys3_off_readdir(thread_job_t *job);
-void sys3_off_rewinddir(thread_job_t *job);
-void sys3_off_opendir2(thread_job_t *job);
+void sys_off_open(job_args_t *job_args);
+void sys_off_creat(job_args_t *job_args);
+void sys_off_read(job_args_t *job_args);
+void sys_off_write(job_args_t *job_args);
+void sys_off_lseek(job_args_t *job_args);
+void sys_off_close(job_args_t *job_args);
+void sys_off_link(job_args_t *job_args);
+void sys_off_unlink(job_args_t *job_args);
+void sys_off_stat(job_args_t *job_args);
+void sys3_off_getcwd(job_args_t *job_args);
+void sys3_off_system(job_args_t *job_args);
+void sys_off_chdir(job_args_t *job_args);
+void sys3_off_opendir(job_args_t *job_args);
+void sys3_off_closedir(job_args_t *job_args);
+void sys3_off_readdir(job_args_t *job_args);
+void sys3_off_rewinddir(job_args_t *job_args);
+void sys3_off_opendir2(job_args_t *job_args);
 
 #endif /*__OFFLOAD_IO_H__*/

--- a/sideloader/offload_proxy/offload_fio.h
+++ b/sideloader/offload_proxy/offload_fio.h
@@ -1,27 +1,25 @@
 #ifndef __OFFLOAD_FIO_H__
 #define __OFFLOAD_FIO_H__
 
-#include <dirent.h>
-
 #include "offload_channel.h"
 #include "offload_message.h"
 
-void sys_off_open(struct channel_struct *ch);
-void sys_off_creat(struct channel_struct *ch);
-void sys_off_read(struct channel_struct *ch);
-void sys_off_write(struct channel_struct *ch);
-void sys_off_lseek(struct channel_struct *ch);
-void sys_off_close(struct channel_struct *ch);
-void sys_off_link(struct channel_struct *ch);
-void sys_off_unlink(struct channel_struct *ch);
-void sys_off_stat(struct channel_struct *ch);
-void sys3_off_getcwd(struct channel_struct *ch);
-void sys3_off_system(struct channel_struct *ch);
-void sys_off_chdir(struct channel_struct *ch);
-void sys3_off_opendir(struct channel_struct *ch);
-void sys3_off_closedir(struct channel_struct *ch);
-void sys3_off_readdir(struct channel_struct *ch);
-void sys3_off_rewinddir(struct channel_struct *ch);
-void sys3_off_opendir2(struct channel_struct *ch);
+void sys_off_open(thread_job_t *job);
+void sys_off_creat(thread_job_t *job);
+void sys_off_read(thread_job_t *job);
+void sys_off_write(thread_job_t *job);
+void sys_off_lseek(thread_job_t *job);
+void sys_off_close(thread_job_t *job);
+void sys_off_link(thread_job_t *job);
+void sys_off_unlink(thread_job_t *job);
+void sys_off_stat(thread_job_t *job);
+void sys3_off_getcwd(thread_job_t *job);
+void sys3_off_system(thread_job_t *job);
+void sys_off_chdir(thread_job_t *job);
+void sys3_off_opendir(thread_job_t *job);
+void sys3_off_closedir(thread_job_t *job);
+void sys3_off_readdir(thread_job_t *job);
+void sys3_off_rewinddir(thread_job_t *job);
+void sys3_off_opendir2(thread_job_t *job);
 
 #endif /*__OFFLOAD_IO_H__*/

--- a/sideloader/offload_proxy/offload_message.h
+++ b/sideloader/offload_proxy/offload_message.h
@@ -27,11 +27,6 @@ typedef struct io_packet_struct {
   unsigned long ret;          
 } io_packet_t;
 
-typedef struct thread_job {
-   channel_t *ch;
-   io_packet_t pkt;
-} thread_job_t;
-
 void send_offload_message(struct circular_queue *out_cq, int tid, int offload_function_type, unsigned long  ret);
 
 #endif //__OFFLOAD_MESSAGE_H__

--- a/sideloader/offload_proxy/offload_message.h
+++ b/sideloader/offload_proxy/offload_message.h
@@ -27,6 +27,11 @@ typedef struct io_packet_struct {
   unsigned long ret;          
 } io_packet_t;
 
+typedef struct thread_job {
+   channel_t *ch;
+   io_packet_t pkt;
+} thread_job_t;
+
 void send_offload_message(struct circular_queue *out_cq, int tid, int offload_function_type, unsigned long  ret);
 
 #endif //__OFFLOAD_MESSAGE_H__

--- a/sideloader/offload_proxy/offload_network.c
+++ b/sideloader/offload_proxy/offload_network.c
@@ -1,6 +1,7 @@
 #include "offload_network.h"
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -17,9 +18,8 @@
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_gethostname(struct channel_struct *ch)
+void sys_off_gethostname(thread_job_t *job)
 {
-  struct circular_queue *in_cq = NULL;
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
   int tid = 0;
@@ -29,9 +29,10 @@ void sys_off_gethostname(struct channel_struct *ch)
   int len = 0;
 
   // Get the queue information
-  in_cq = ch->in_cq;
-  out_cq = ch->out_cq;
-  in_pkt = (io_packet_t *) (in_cq->data + in_cq->tail);
+  struct channel_struct *ch;
+  ch = job->ch;
+  out_cq = job->ch->out_cq;
+  in_pkt = (io_packet_t *) &job->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -39,16 +40,15 @@ void sys_off_gethostname(struct channel_struct *ch)
   name = (char *) get_va(in_pkt->param1);
   len = (int) in_pkt->param2;
 
-  // Empty in_cq
-  in_cq->tail = (in_cq->tail + 1) % in_cq->size;
-
   // Execute gethostname systemcall
   ret = gethostname(name, len); 
   if(ret == -1)
 	fprintf(stderr, "%s\n", strerror(errno));
 
   // Sent to the result to the kernel
+  pthread_mutex_lock(&ch->mutex);
   send_offload_message(out_cq, tid, offload_function_type, (int) ret);
+  pthread_mutex_unlock(&ch->mutex);
 }
 
 /**
@@ -56,9 +56,8 @@ void sys_off_gethostname(struct channel_struct *ch)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_gethostbyname(struct channel_struct *ch)
+void sys_off_gethostbyname(thread_job_t *job)
 {
-  struct circular_queue *in_cq = NULL;
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
   int tid = 0;
@@ -73,9 +72,10 @@ void sys_off_gethostbyname(struct channel_struct *ch)
   char *h_addr;
 
   // Get the queue information
-  in_cq = ch->in_cq;
-  out_cq = ch->out_cq;
-  in_pkt = (io_packet_t *) (in_cq->data + in_cq->tail);
+  struct channel_struct *ch;
+  ch = job->ch;
+  out_cq = job->ch->out_cq;
+  in_pkt = (io_packet_t *) &job->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -87,9 +87,6 @@ void sys_off_gethostbyname(struct channel_struct *ch)
   h_addrtype = (int *) get_va(in_pkt->param4);
   h_length = (int *) get_va(in_pkt->param5);
   h_addr = (char *) get_va(in_pkt->param6);
-
-  // Empty in_cq
-  in_cq->tail = (in_cq->tail + 1) % in_cq->size;
 
   // Execute gethostbyname systemcall
   ret = gethostbyname(name);
@@ -114,7 +111,9 @@ void sys_off_gethostbyname(struct channel_struct *ch)
   }
 
   // Sent to the result to the kernel
+  pthread_mutex_lock(&ch->mutex);
   send_offload_message(out_cq, tid, offload_function_type, (unsigned long) ret);
+  pthread_mutex_unlock(&ch->mutex);
 }
 
 /**
@@ -122,9 +121,8 @@ void sys_off_gethostbyname(struct channel_struct *ch)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_getsockname(struct channel_struct *ch)
+void sys_off_getsockname(thread_job_t *job)
 {
-  struct circular_queue *in_cq = NULL;
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
   int tid = 0;
@@ -135,9 +133,10 @@ void sys_off_getsockname(struct channel_struct *ch)
   int iret = -1;
 
   // Get the queue information
-  in_cq = ch->in_cq;
-  out_cq = ch->out_cq;
-  in_pkt = (io_packet_t *) (in_cq->data + in_cq->tail);
+  struct channel_struct *ch;
+  ch = job->ch;
+  out_cq = job->ch->out_cq;
+  in_pkt = (io_packet_t *) &job->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -146,16 +145,15 @@ void sys_off_getsockname(struct channel_struct *ch)
   addr = (struct sockaddr *) get_va(in_pkt->param2);
   addrlen = (socklen_t *) get_va(in_pkt->param3);
 
-  // Empty in_cq
-  in_cq->tail = (in_cq->tail + 1) % in_cq->size;
-
   // Execute getsockname systemcall
   iret = getsockname(sockfd, addr, addrlen);
   if(iret == -1)
     fprintf(stderr, "%s\n", strerror(errno));
 
   // Sent to the result to the kernel
+  pthread_mutex_lock(&ch->mutex);
   send_offload_message(out_cq, tid, offload_function_type, (unsigned long) iret);
+  pthread_mutex_unlock(&ch->mutex);
 }
 
 /**
@@ -163,9 +161,8 @@ void sys_off_getsockname(struct channel_struct *ch)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_socket(struct channel_struct *ch)
+void sys_off_socket(thread_job_t *job)
 {
-  struct circular_queue *in_cq = NULL;
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
   int tid = 0;
@@ -176,9 +173,10 @@ void sys_off_socket(struct channel_struct *ch)
   int iret = -1;
 
   // Get the queue information
-  in_cq = ch->in_cq;
-  out_cq = ch->out_cq;
-  in_pkt = (io_packet_t *) (in_cq->data + in_cq->tail);
+  struct channel_struct *ch;
+  ch = job->ch;
+  out_cq = job->ch->out_cq;
+  in_pkt = (io_packet_t *) &job->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -187,16 +185,15 @@ void sys_off_socket(struct channel_struct *ch)
   type = (int) in_pkt->param2; 
   protocol = (int) in_pkt->param3;
 
-  // Empty in_cq
-  in_cq->tail = (in_cq->tail + 1) % in_cq->size;
-
   // Execute socket systemcall
   iret = socket(domain, type, protocol);
   if(iret == -1)
     fprintf(stderr, "%s\n", strerror(errno));
 
   // Sent to the result to the kernel
+  pthread_mutex_lock(&ch->mutex);
   send_offload_message(out_cq, tid, offload_function_type, (unsigned long) iret);
+  pthread_mutex_unlock(&ch->mutex);
 }
 
 /**
@@ -204,9 +201,8 @@ void sys_off_socket(struct channel_struct *ch)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_bind(struct channel_struct *ch)
+void sys_off_bind(thread_job_t *job)
 {
-  struct circular_queue *in_cq = NULL;
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
   int tid = 0;
@@ -217,9 +213,10 @@ void sys_off_bind(struct channel_struct *ch)
   int iret = 0;
 
   // Get the queue information
-  in_cq = ch->in_cq;
-  out_cq = ch->out_cq;
-  in_pkt = (io_packet_t *) (in_cq->data + in_cq->tail);
+  struct channel_struct *ch;
+  ch = job->ch;
+  out_cq = job->ch->out_cq;
+  in_pkt = (io_packet_t *) &job->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -228,16 +225,15 @@ void sys_off_bind(struct channel_struct *ch)
   addr = (struct sockaddr *) get_va(in_pkt->param2);
   addrlen = (socklen_t) in_pkt->param3;
 
-  // Empty in_cq
-  in_cq->tail = (in_cq->tail + 1) % in_cq->size;
-
   // Execute bind systemcall
   iret = bind(sockfd, addr, addrlen);
   if(iret == -1)
     fprintf(stderr, "%s\n", strerror(errno));
 
   // Sent to the result to the kernel
+  pthread_mutex_lock(&ch->mutex);
   send_offload_message(out_cq, tid, offload_function_type, (unsigned long) iret);
+  pthread_mutex_unlock(&ch->mutex);
 }
 
 /**
@@ -245,9 +241,8 @@ void sys_off_bind(struct channel_struct *ch)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_listen(struct channel_struct *ch)
+void sys_off_listen(thread_job_t *job)
 {
-  struct circular_queue *in_cq = NULL;
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
   int tid = 0;
@@ -257,9 +252,10 @@ void sys_off_listen(struct channel_struct *ch)
   int iret = -1;
 
   // Get the queue information
-  in_cq = ch->in_cq;
-  out_cq = ch->out_cq;
-  in_pkt = (io_packet_t *) (in_cq->data + in_cq->tail);
+  struct channel_struct *ch;
+  ch = job->ch;
+  out_cq = job->ch->out_cq;
+  in_pkt = (io_packet_t *) &job->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -267,16 +263,15 @@ void sys_off_listen(struct channel_struct *ch)
   sockfd = (int) in_pkt->param1;
   backlog = (int) in_pkt->param2;
 
-  // Empty in_cq
-  in_cq->tail = (in_cq->tail + 1) % in_cq->size;
-
   // Execute listen systemcall
   iret = listen(sockfd, backlog);
   if(iret == -1)
     fprintf(stderr, "%s\n", strerror(errno));
 
   // Sent to the result to the kernel
+  pthread_mutex_lock(&ch->mutex);
   send_offload_message(out_cq, tid, offload_function_type, (unsigned long) iret);
+  pthread_mutex_unlock(&ch->mutex);
 }
 
 /**
@@ -284,9 +279,8 @@ void sys_off_listen(struct channel_struct *ch)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_connect(struct channel_struct *ch)
+void sys_off_connect(thread_job_t *job)
 {
-  struct circular_queue *in_cq = NULL;
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
   int tid = 0;
@@ -297,9 +291,10 @@ void sys_off_connect(struct channel_struct *ch)
   int iret = -1;
 
   // Get the queue information
-  in_cq = ch->in_cq;
-  out_cq = ch->out_cq;
-  in_pkt = (io_packet_t *) (in_cq->data + in_cq->tail);
+  struct channel_struct *ch;
+  ch = job->ch;
+  out_cq = job->ch->out_cq;
+  in_pkt = (io_packet_t *) &job->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -308,16 +303,15 @@ void sys_off_connect(struct channel_struct *ch)
   addr = (struct sockaddr *) get_va(in_pkt->param2);
   addrlen = (socklen_t) in_pkt->param3; 
 
-  // Empty in_cq
-  in_cq->tail = (in_cq->tail + 1) % in_cq->size;
-
   // Execute connect systemcall
   iret = connect(sockfd, addr, addrlen);
   if(iret == -1)
     fprintf(stderr, "%s\n", strerror(errno));
 
   // Sent to the result to the kernel
+  pthread_mutex_lock(&ch->mutex);
   send_offload_message(out_cq, tid, offload_function_type, (unsigned long) iret);
+  pthread_mutex_unlock(&ch->mutex);
 }
 
 /**
@@ -325,9 +319,8 @@ void sys_off_connect(struct channel_struct *ch)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_accept(struct channel_struct *ch)
+void sys_off_accept(thread_job_t *job)
 {
-  struct circular_queue *in_cq = NULL;
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
   int tid = 0;
@@ -338,9 +331,10 @@ void sys_off_accept(struct channel_struct *ch)
   int iret = -1;
 
   // Get the queue information
-  in_cq = ch->in_cq;
-  out_cq = ch->out_cq;
-  in_pkt = (io_packet_t *) (in_cq->data + in_cq->tail);
+  struct channel_struct *ch;
+  ch = job->ch;
+  out_cq = job->ch->out_cq;
+  in_pkt = (io_packet_t *) &job->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -349,14 +343,13 @@ void sys_off_accept(struct channel_struct *ch)
   addr = (struct sockaddr *) get_va(in_pkt->param2);
   addrlen = (socklen_t *) get_va(in_pkt->param3);
 
-  // Empty in_cq
-  in_cq->tail = (in_cq->tail + 1) % in_cq->size;
-
   // Execute accept systemcall
   iret = accept(sockfd, addr, addrlen);
   if(iret == -1)
       fprintf(stderr, "%s\n", strerror(errno));
 
   // Sent to the result to the kernel
+  pthread_mutex_lock(&ch->mutex);
   send_offload_message(out_cq, tid, offload_function_type, (unsigned long) iret);
+  pthread_mutex_unlock(&ch->mutex);
 }

--- a/sideloader/offload_proxy/offload_network.c
+++ b/sideloader/offload_proxy/offload_network.c
@@ -12,13 +12,14 @@
 #include "offload_channel.h"
 #include "offload_message.h"
 #include "offload_mmap.h"
+#include "offload_thread_pool.h"
 
 /**
  * @brief Receive the request from the queue, Execute gethostname systemcall then return the result
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_gethostname(thread_job_t *job)
+void sys_off_gethostname(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -30,9 +31,9 @@ void sys_off_gethostname(thread_job_t *job)
 
   // Get the queue information
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -56,7 +57,7 @@ void sys_off_gethostname(thread_job_t *job)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_gethostbyname(thread_job_t *job)
+void sys_off_gethostbyname(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -73,9 +74,9 @@ void sys_off_gethostbyname(thread_job_t *job)
 
   // Get the queue information
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -121,7 +122,7 @@ void sys_off_gethostbyname(thread_job_t *job)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_getsockname(thread_job_t *job)
+void sys_off_getsockname(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -134,9 +135,9 @@ void sys_off_getsockname(thread_job_t *job)
 
   // Get the queue information
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -161,7 +162,7 @@ void sys_off_getsockname(thread_job_t *job)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_socket(thread_job_t *job)
+void sys_off_socket(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -174,9 +175,9 @@ void sys_off_socket(thread_job_t *job)
 
   // Get the queue information
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -201,7 +202,7 @@ void sys_off_socket(thread_job_t *job)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_bind(thread_job_t *job)
+void sys_off_bind(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -214,9 +215,9 @@ void sys_off_bind(thread_job_t *job)
 
   // Get the queue information
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -241,7 +242,7 @@ void sys_off_bind(thread_job_t *job)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_listen(thread_job_t *job)
+void sys_off_listen(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -253,9 +254,9 @@ void sys_off_listen(thread_job_t *job)
 
   // Get the queue information
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -279,7 +280,7 @@ void sys_off_listen(thread_job_t *job)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_connect(thread_job_t *job)
+void sys_off_connect(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -292,9 +293,9 @@ void sys_off_connect(thread_job_t *job)
 
   // Get the queue information
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;
@@ -319,7 +320,7 @@ void sys_off_connect(thread_job_t *job)
  * @param ch- channel defined and allocated in the shared memory
  * @return none
  */
-void sys_off_accept(thread_job_t *job)
+void sys_off_accept(job_args_t *job_args)
 {
   struct circular_queue *out_cq = NULL;
   io_packet_t *in_pkt = NULL;
@@ -332,9 +333,9 @@ void sys_off_accept(thread_job_t *job)
 
   // Get the queue information
   struct channel_struct *ch;
-  ch = job->ch;
-  out_cq = job->ch->out_cq;
-  in_pkt = (io_packet_t *) &job->pkt;
+  ch = job_args->ch;
+  out_cq = job_args->ch->out_cq;
+  in_pkt = (io_packet_t *) &job_args->pkt;
 
   // Receive parameters passed from the queue
   tid = (int) in_pkt->tid;

--- a/sideloader/offload_proxy/offload_network.h
+++ b/sideloader/offload_proxy/offload_network.h
@@ -3,14 +3,15 @@
 
 #include "offload_channel.h"
 #include "offload_message.h"
+#include "offload_thread_pool.h"
 
-void sys_off_gethostname(thread_job_t *job);
-void sys_off_gethostbyname(thread_job_t *job);
-void sys_off_getsockname(thread_job_t *job);
-void sys_off_socket(thread_job_t *job);
-void sys_off_bind(thread_job_t *job);
-void sys_off_listen(thread_job_t *job);
-void sys_off_connect(thread_job_t *job);
-void sys_off_accept(thread_job_t *job);
+void sys_off_gethostname(job_args_t *job_args);
+void sys_off_gethostbyname(job_args_t *job_args);
+void sys_off_getsockname(job_args_t *job_args);
+void sys_off_socket(job_args_t *job_args);
+void sys_off_bind(job_args_t *job_args);
+void sys_off_listen(job_args_t *job_args);
+void sys_off_connect(job_args_t *job_args);
+void sys_off_accept(job_args_t *job_args);
 
 #endif /* __OFFLOAD_NETWORK_H__ */

--- a/sideloader/offload_proxy/offload_network.h
+++ b/sideloader/offload_proxy/offload_network.h
@@ -4,13 +4,13 @@
 #include "offload_channel.h"
 #include "offload_message.h"
 
-void sys_off_gethostname(struct channel_struct *ch);
-void sys_off_gethostbyname(struct channel_struct *ch);
-void sys_off_getsockname(struct channel_struct *ch);
-void sys_off_socket(struct channel_struct *ch);
-void sys_off_bind(struct channel_struct *ch);
-void sys_off_listen(struct channel_struct *ch);
-void sys_off_connect(struct channel_struct *ch);
-void sys_off_accept(struct channel_struct *ch);
+void sys_off_gethostname(thread_job_t *job);
+void sys_off_gethostbyname(thread_job_t *job);
+void sys_off_getsockname(thread_job_t *job);
+void sys_off_socket(thread_job_t *job);
+void sys_off_bind(thread_job_t *job);
+void sys_off_listen(thread_job_t *job);
+void sys_off_connect(thread_job_t *job);
+void sys_off_accept(thread_job_t *job);
 
 #endif /* __OFFLOAD_NETWORK_H__ */

--- a/sideloader/offload_proxy/offload_thread_pool.c
+++ b/sideloader/offload_proxy/offload_thread_pool.c
@@ -461,7 +461,11 @@ void suspend_pool(thread_pool_t *pool){
 /* Resume a suspended pool. See header for more
  * details.
  */
+<<<<<<< HEAD
+void resume_pool(thread_pool_t *pool){
+=======
 void resumePool(thread_pool_t *pool){
+>>>>>>> fdb55f0c5a2912199e7add48bd7698f493a7f7f0
 	if(pool==NULL || !pool->is_initialized){ // Sanity check
 		printf("\n[THREADPOOL:RESM:ERROR] Pool is not initialized!");
 		return;

--- a/sideloader/offload_proxy/offload_thread_pool.c
+++ b/sideloader/offload_proxy/offload_thread_pool.c
@@ -1,0 +1,740 @@
+/*   MyThreads : A small, efficient, and fast threadpool implementation in C
+ *   Copyright (C) 2017  Subhranil Mukherjee (https://github.com/iamsubhranil)
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 3 of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if 0
+#include <pthread.h> // The thread library
+#include <stdio.h> // Standard output functions in case of errors and debug
+#include <stdlib.h> // Memory management functions
+#include <inttypes.h> // Standard integer format specifiers
+#endif
+
+#include "offload_thread_pool.h" // API header
+
+#if 0
+/* A singly linked list of threads. This list
+ * gives tremendous flexibility managing the 
+ * threads at runtime.
+ */
+typedef struct ThreadList {
+	pthread_t thread; // The thread object
+	struct ThreadList *next; // Link to next thread
+} ThreadList;
+
+/* A singly linked list of worker functions. This
+ * list is implemented as a queue to manage the
+ * execution in the pool.
+ */
+typedef struct Job {
+	void (*function)(void *); // The worker function
+	void *args; // Argument to the function
+	struct Job *next; // Link to next Job
+} Job;
+
+/* The core pool structure. This is the only
+ * user accessible structure in the API. It contains
+ * all the primitives necessary to provide
+ * synchronization between the threads, along with
+ * dynamic management and execution control.
+ */
+struct ThreadPool {
+	/* The FRONT of the thread queue in the pool.
+	 * It typically points to the first thread
+	 * created in the pool.
+	 */
+	ThreadList * threads;
+
+	/* The REAR of the thread queue in the pool.
+	 * Points to the last, and most young thread
+	 * added to the pool.
+	 */
+	ThreadList * rearThreads;
+
+	/* Number of threads in the pool. As this can
+	 * grow dynamically, access and modification 
+	 * of it is bounded by a mutex.
+	 */
+	uint64_t numThreads;
+
+	/* The indicator which indicates the number
+	 * of threads to remove. If this is equal to
+	 * N, then N threads will be removed from the
+	 * pool when they are idle. All threads
+	 * typically check the value of this variable
+	 * before executing a job, and if finds the 
+	 * value >0, immediately exits.
+	 */
+	uint64_t removeThreads;
+
+	/* Denotes the number of idle threads in the
+	 * pool at any given instant of time. This value
+	 * is used to check if all threads are idle,
+	 * and thus triggering the end of job queue or
+	 * the initialization of the pool, whichever
+	 * applicable.
+	 */
+	volatile uint64_t waitingThreads;
+
+	/* Denotes whether the pool is presently
+	 * initalized or not. This variable is used to
+	 * busy wait after the creation of the pool
+	 * to ensure all threads are in waiting state.
+	 */
+	volatile uint8_t isInitialized;
+
+	/* The main mutex for the job queue. All
+	 * operations on the queue is done after locking
+	 * this mutex to ensure consistency.
+	 */
+	pthread_mutex_t queuemutex;
+
+	/* This mutex indicates whether a thread is
+	 * presently in idle state or not, and is used
+	 * in conjunction with the conditional below.
+	 */
+	pthread_mutex_t condmutex;
+
+	/* Conditional to ensure conditional wait.
+	 * When idle, each thread waits on this 
+	 * conditional, which is signaled by various
+	 * methods to indicate the wake of the thread.
+	 */
+	pthread_cond_t conditional;
+
+	/* Ensures pool state. When the pool is running,
+	 * this is set to 1. All the threads loop on
+	 * this condition, and exits immediately when
+	 * it is set to 0, which happens when the pool
+	 * is destroyed.
+	 */
+	_Atomic uint8_t run;
+
+	/* Used to assign unique thread IDs to each
+	 * running threads. It is an always incremental
+	 * counter.
+	 */
+	uint64_t threadID;
+
+	/* The FRONT of the job queue, which typically
+	 * points to the job to be executed next.
+	 */
+	Job *FRONT;
+
+	/* The REAR of the job queue, which points
+	 * to the job last added in the pool.
+	 */
+	Job *REAR;
+
+	/* Mutex used to denote the end of the job
+	 * queue, which triggers the function
+	 * waitForComplete.
+	 */
+	pthread_mutex_t endmutex;
+
+	/* Conditional to signal the end of the job
+	 * queue.
+	 */
+	pthread_cond_t endconditional;
+	
+	/* Variable to impose and withdraw
+	 * the suspend state.
+	 */
+	uint8_t suspend;
+
+	/* Counter to the number of jobs
+	 * present in the job queue
+	 */
+	_Atomic uint64_t jobCount;
+};
+#endif
+
+/* The core function which is executed in each thread.
+ * A pointer to the pool is passed as the argument,
+ * which controls the flow of execution of the thread.
+ */
+static void *threadExecutor(void *pl){
+	ThreadPool *pool = (ThreadPool *)pl; // Get the pool
+	pthread_mutex_lock(&pool->queuemutex); // Lock the mutex
+	++pool->threadID; // Get an id
+
+#ifdef DEBUG
+    uint64_t id = pool->threadID;
+#endif
+
+	pthread_mutex_unlock(&pool->queuemutex); // Release the mutex
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Starting execution loop!", id);
+#endif
+	//Start the core execution loop
+	while(atomic_get(&pool->run)){ // run==1, we should get going
+#ifdef DEBUG
+		printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Trying to lock the mutex!", id);
+#endif
+
+		pthread_mutex_lock(&pool->queuemutex); //Lock the queue mutex
+
+		if(pool->removeThreads>0){ // A thread is needed to be removed
+#ifdef DEBUG
+			printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Removal signalled! Exiting the execution loop!", id);
+#endif
+			pthread_mutex_lock(&pool->condmutex);
+			pool->numThreads--;
+			pthread_mutex_unlock(&pool->condmutex);
+			break; // Exit the loop
+		}
+		Job *presentJob = pool->FRONT; // Get the first job
+		if(presentJob==NULL || pool->suspend){ // Queue is empty!
+
+#ifdef DEBUG
+			if(presentJob==NULL)
+				printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Queue is empty! Unlocking the mutex!", id);
+			else
+				printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Suspending thread!", id);
+#endif
+			pthread_mutex_unlock(&pool->queuemutex); // Unlock the mutex
+
+			pthread_mutex_lock(&pool->condmutex); // Hold the conditional mutex
+			pool->waitingThreads++; // Add yourself as a waiting thread
+#ifdef DEBUG
+			printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Waiting threads %" PRIu64 "!", id, pool->waitingThreads);
+#endif
+			if(!pool->suspend && pool->waitingThreads==pool->numThreads){ // All threads are idle
+#ifdef DEBUG
+				printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] All threads are idle now!", id);
+#endif
+				if(pool->isInitialized){ // Pool is initialized, time to trigger the end conditional
+#ifdef DEBUG
+					printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Signaling endconditional!" ,id);
+					fflush(stdout);
+#endif
+					pthread_mutex_lock(&pool->endmutex); // Lock the mutex
+					pthread_cond_signal(&pool->endconditional); // Signal the end
+					pthread_mutex_unlock(&pool->endmutex); // Release the mutex
+#ifdef DEBUG
+					printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Signalled any monitor!", id);
+#endif
+				}
+				else // We are initializing the pool
+					pool->isInitialized = 1; // Break the busy wait
+			}
+
+
+
+#ifdef DEBUG
+			printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Going to conditional wait!", id);
+			fflush(stdout);
+#endif
+			pthread_cond_wait(&pool->conditional, &pool->condmutex); // Idle wait on conditional
+			
+			/* Woke up! */
+
+			if(pool->waitingThreads>0) // Unregister youself as a waiting thread
+				pool->waitingThreads--;
+
+			pthread_mutex_unlock(&pool->condmutex); // Woke up! Release the mutex
+
+#ifdef DEBUG
+			printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Woke up from conditional wait!", id);
+#endif			
+		}
+		else{ // There is a job in the pool
+
+			pool->FRONT = pool->FRONT->next; // Shift FRONT to right
+			atomic64_dec(&pool->jobCount); // Decrement the count
+			
+			if(pool->FRONT==NULL) // No jobs next
+				pool->REAR = NULL; // Reset the REAR
+#ifdef DEBUG
+			else
+				printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Remaining jobs : %" PRIu64, id, atomic64_read(&pool->jobCount));
+
+			printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Job recieved! Unlocking the mutex!", id);
+#endif
+			
+
+			pthread_mutex_unlock(&pool->queuemutex); // Unlock the mutex
+
+#ifdef DEBUG
+			printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Executing the job now!", id);
+			fflush(stdout);
+#endif
+
+			presentJob->function(presentJob->args); // Execute the job
+
+#ifdef DEBUG
+			printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Job completed! Releasing memory for the job!", id);
+#endif
+
+			free(presentJob); // Release memory for the job
+		}
+	}
+
+	
+	if(atomic_get(&pool->run)){ // We exited, but the pool is running! It must be force removal!
+#ifdef DEBUG
+		printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Releasing the lock!", id);
+#endif
+		pool->removeThreads--; // Alright, I'm shutting now
+		pthread_mutex_unlock(&pool->queuemutex); // We broke the loop, release the mutex now
+#ifdef DEBUG
+		printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Stopping now..", id);
+		fflush(stdout);
+#endif
+	}
+#ifdef DEBUG
+	else // The pool is stopped
+		printf("\n[THREADPOOL:THREAD%" PRIu64 ":INFO] Pool has been stopped! Exiting now..", id);
+#endif
+
+	pthread_exit((void *)COMPLETED); // Exit
+}
+
+/* This method adds 'threads' number of new threads
+ * to the argument pool. See header for more details.
+ */
+ThreadPoolStatus addThreadsToPool(ThreadPool *pool, uint64_t threads){
+	if(pool==NULL){ // Sanity check
+		printf("\n[THREADPOOL:ADD:ERROR] Pool is not initialized!");
+		return POOL_NOT_INITIALIZED;
+	}
+	if(!atomic_get(&pool->run)){
+		printf("\n[THREADPOOL:ADD:ERROR] Pool already stopped!");
+		return POOL_STOPPED;
+	}
+	if(threads < 1){
+		printf("\n[THREADPOOL:ADD:WARNING] Tried to add invalid number of threads %" PRIu64 "!", threads);
+		return INVALID_NUMBER;
+	}
+
+	int temp = 0;
+	ThreadPoolStatus rc = COMPLETED;
+#ifdef DEBUG
+	printf("\n[THREADPOOL:ADD:INFO] Holding the condmutex..");
+#endif
+	pthread_mutex_lock(&pool->condmutex);
+	pool->numThreads += threads; // Increment the thread count to prevent idle signal
+	pthread_mutex_unlock(&pool->condmutex);
+#ifdef DEBUG
+	printf("\n[THREADPOOL:ADD:INFO] Speculative increment done!");
+#endif
+	uint64_t i = 0;
+	for(i = 0;i < threads;i++){
+
+		ThreadList *newThread = (ThreadList *)malloc(sizeof(ThreadList)); // Allocate a new thread
+		newThread->next = NULL;
+		temp = pthread_create(&newThread->thread, NULL, threadExecutor, (void *)pool); // Start the thread
+		if(temp){
+			printf("\n[THREADPOOL:ADD:ERROR] Unable to create thread %" PRIu64 "(error code %d)!", (i+1), temp);
+			pthread_mutex_lock(&pool->condmutex);
+			pool->numThreads--;
+			pthread_mutex_unlock(&pool->condmutex);
+			temp = 0;
+			rc = THREAD_CREATION_FAILED;
+		}
+		else{
+#ifdef DEBUG
+			printf("\n[THREADPOOL:ADD:INFO] Initialized thread %" PRIu64 "!", (i+1));
+#endif
+			if(pool->rearThreads==NULL) // This is the first thread
+				pool->threads = pool->rearThreads = newThread;
+			else // There are threads in the pool
+				pool->rearThreads->next = newThread;
+			pool->rearThreads = newThread; // This is definitely the last thread
+		}
+	}
+	return rc;
+}
+
+/* This method removes one thread from the
+ * argument pool. See header for more details.
+ */
+void removeThreadFromPool(ThreadPool *pool){
+	if(pool==NULL || !pool->isInitialized){
+		printf("\n[THREADPOOL:REM:ERROR] Pool is not initialized!");
+		return;
+	}
+	if(!atomic_get(&pool->run)){
+		printf("\n[THREADPOOL:REM:WARNING] Removing thread from a stopped pool!");
+		return;
+	}
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:REM:INFO] Acquiring the lock!");
+#endif
+	pthread_mutex_lock(&pool->queuemutex); // Lock the mutex
+#ifdef DEBUG
+	printf("\n[THREADPOOL:REM:INFO] Incrementing the removal count");
+#endif
+	pool->removeThreads++; // Indicate the willingness of removal
+	pthread_mutex_unlock(&pool->queuemutex); // Unlock the mutex
+#ifdef DEBUG
+	printf("\n[THREADPOOL:REM:INFO] Waking up any sleeping threads!");
+#endif
+	pthread_mutex_lock(&pool->condmutex); // Lock the wait mutex
+	pthread_cond_signal(&pool->conditional); // Signal any idle threads
+	pthread_mutex_unlock(&pool->condmutex); // Release the wait mutex
+#ifdef DEBUG
+	printf("\n[THREADPOOL:REM:INFO] Signalling complete!");
+#endif
+}
+
+/* This method creates a new thread pool containing
+ * argument number of threads. See header for more
+ * details.
+ */
+
+ThreadPool * createPool(uint64_t numThreads){
+	ThreadPool * pool = (ThreadPool *)malloc(sizeof(ThreadPool)); // Allocate memory for the pool
+	if(pool==NULL){ // Oops!
+		printf("[THREADPOOL:INIT:ERROR] Unable to allocate memory for the pool!");
+		return NULL;
+	}
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:INIT:INFO] Allocated %zu bytes for new pool!", sizeof(ThreadPool));
+#endif
+	// Initialize members with default values
+	pool->numThreads = 0; 
+	pool->FRONT = NULL;
+	pool->REAR = NULL;
+	pool->waitingThreads = 0;
+	pool->isInitialized = 0;
+	pool->removeThreads = 0;
+	pool->suspend = 0;
+	pool->rearThreads = NULL;
+	pool->threads = NULL;
+	atomic64_set(&pool->jobCount, 0);
+    pool->threadID = 0;
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:INIT:INFO] Initializing mutexes!");
+#endif
+
+	pthread_mutex_init(&pool->queuemutex, NULL); // Initialize queue mutex
+	pthread_mutex_init(&pool->condmutex, NULL); // Initialize idle mutex
+	pthread_mutex_init(&pool->endmutex, NULL); // Initialize end mutex
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:INIT:INFO] Initiliazing conditionals!");
+#endif
+
+	pthread_cond_init(&pool->endconditional, NULL); // Initialize end conditional
+	pthread_cond_init(&pool->conditional, NULL); // Initialize idle conditional
+	
+	atomic_set(&pool->run, 1); // Start the pool
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:INIT:INFO] Successfully initialized all members of the pool!");
+	printf("\n[THREADPOOL:INIT:INFO] Initializing %" PRIu64 " threads..",numThreads);
+#endif
+	
+	if(numThreads<1){
+		printf("\n[THREADPOOL:INIT:WARNING] Starting with no threads!");
+		pool->isInitialized = 1;
+	}
+	else{
+		addThreadsToPool(pool, numThreads); // Add threads to the pool
+#ifdef DEBUG
+		printf("\n[THREADPOOL:INIT:INFO] Waiting for all threads to start..");
+#endif
+	}
+
+	while(!pool->isInitialized); // Busy wait till the pool is initialized
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:INIT:INFO] New threadpool initialized successfully!");
+#endif
+
+	return pool;
+}
+
+/* Adds a new job to pool. See header for more
+ * details.
+ *
+ */
+ThreadPoolStatus addJobToPool(ThreadPool *pool, void (*func)(void *args), void *args){
+	if(pool==NULL || !pool->isInitialized){ // Sanity check
+		printf("\n[THREADPOOL:EXEC:ERROR] Pool is not initialized!");
+		return POOL_NOT_INITIALIZED;
+	}
+	if(!atomic_get(&pool->run)){
+		printf("\n[THREADPOOL:EXEC:ERROR] Trying to add a job in a stopped pool!");
+		return POOL_STOPPED;
+	}
+	if(atomic_get(&pool->run)==2){
+		printf("\n[THREADPOOL:EXEC:WARNING] Another thread is waiting for the pool to complete!");
+		return WAIT_ISSUED;
+	}
+
+	Job *newJob = (Job *)malloc(sizeof(Job)); // Allocate memory
+	if(newJob==NULL){ // Who uses 2KB RAM nowadays?
+		printf("\n[THREADPOOL:EXEC:ERROR] Unable to allocate memory for new job!");
+		return MEMORY_UNAVAILABLE;
+	}
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXEC:INFO] Allocated %zu bytes for new job!", sizeof(Job));
+#endif
+
+	newJob->function = func; // Initialize the function
+	newJob->args = args; // Initialize the argument
+	newJob->next = NULL; // Reset the link
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXEC:INFO] Locking the queue for insertion of the job!");
+#endif
+
+	pthread_mutex_lock(&pool->queuemutex); // Inserting the job, lock the queue
+
+	if(pool->FRONT==NULL) // This is the first job
+		pool->FRONT = pool->REAR = newJob;
+	else // There are other jobs
+		pool->REAR->next = newJob;
+	pool->REAR = newJob; // This is the last job
+
+	atomic64_inc(&pool->jobCount); // Increment the count
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXEC:INFO] Inserted the job at the end of the queue!");
+#endif
+
+	if(pool->waitingThreads>0){ // There are some threads sleeping, wake'em up
+#ifdef DEBUG
+		printf("\n[THREADPOOL:EXEC:INFO] Signaling any idle thread!");
+#endif
+		pthread_mutex_lock(&pool->condmutex); // Lock the mutex
+		pthread_cond_signal(&pool->conditional); // Signal the conditional
+		pthread_mutex_unlock(&pool->condmutex); // Release the mutex
+
+#ifdef DEBUG
+		printf("\n[THREADPOOL:EXEC:INFO] Signaling successful!");
+#endif
+	}
+	
+	pthread_mutex_unlock(&pool->queuemutex); // Finally, release the queue
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXEC:INFO] Unlocked the mutex!");
+#endif
+	return COMPLETED;
+}
+
+/* Wait for the pool to finish executing. See header
+ * for more details.
+ */
+void waitToComplete(ThreadPool *pool){
+	if(pool==NULL || !pool->isInitialized){ // Sanity check
+		printf("\n[THREADPOOL:WAIT:ERROR] Pool is not initialized!");
+		return;
+	}
+	if(!atomic_get(&pool->run)){
+		printf("\n[THREADPOOL:WAIT:ERROR] Pool already stopped!");
+		return;
+	}
+
+	atomic_set(&pool->run, 2);
+	
+	pthread_mutex_lock(&pool->condmutex);
+	if(pool->numThreads==pool->waitingThreads){
+#ifdef DEBUG
+		printf("\n[THREADPOOL:WAIT:INFO] All threads are already idle!");
+#endif
+		pthread_mutex_unlock(&pool->condmutex);
+		atomic_set(&pool->run, 1);
+		return;
+	}
+	pthread_mutex_unlock(&pool->condmutex);
+#ifdef DEBUG
+	printf("\n[THREADPOOL:WAIT:INFO] Waiting for all threads to become idle..");
+#endif
+	pthread_mutex_lock(&pool->endmutex); // Lock the mutex
+	pthread_cond_wait(&pool->endconditional, &pool->endmutex); // Wait for end signal
+	pthread_mutex_unlock(&pool->endmutex); // Unlock the mutex
+#ifdef DEBUG
+	printf("\n[THREADPOOL:WAIT:INFO] All threads are idle now!");
+#endif
+	atomic_set(&pool->run, 1);
+}
+
+/* Suspend all active threads in a pool. See header
+ * for more details.
+ */
+void suspendPool(ThreadPool *pool){
+	if(pool==NULL || !pool->isInitialized){ // Sanity check
+		printf("\n[THREADPOOL:SUSP:ERROR] Pool is not initialized!");
+		return;
+	}
+	if(!atomic_get(&pool->run)){ // Pool is stopped
+		printf("\n[THREADPOOL:SUSP:ERROR] Pool already stopped!");
+		return;
+	}
+	if(pool->suspend){ // Pool is already suspended
+		printf("\n[THREADPOOL:SUSP:ERROR] Pool already suspended!");
+		return;
+	}
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:SUSP:INFO] Initiating suspend..");
+#endif
+	pthread_mutex_lock(&pool->queuemutex); // Lock the queue
+	pool->suspend = 1; // Present the wish for suspension
+	pthread_mutex_unlock(&pool->queuemutex); // Release the queue
+#ifdef DEBUG
+	printf("\n[THREADPOOL:SUSP:INFO] Waiting for all threads to be idle..");
+	fflush(stdout);
+#endif
+	while(pool->waitingThreads<pool->numThreads); // Busy wait till all threads are idle
+#ifdef DEBUG
+	printf("\n[THREADPOOL:SUSP:INFO] Successfully suspended all threads!");
+#endif
+}
+
+/* Resume a suspended pool. See header for more
+ * details.
+ */
+void resumePool(ThreadPool *pool){
+	if(pool==NULL || !pool->isInitialized){ // Sanity check
+		printf("\n[THREADPOOL:RESM:ERROR] Pool is not initialized!");
+		return;
+	}
+	if(!atomic_get(&pool->run)){ // Pool stopped
+		printf("\n[THREADPOOL:RESM:ERROR] Pool is not running!");
+		return;
+	}
+	if(!pool->suspend){ // Pool is not suspended
+		printf("\n[THREADPOOL:RESM:WARNING] Pool is not suspended!");
+		return;
+	}
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:RESM:INFO] Initiating resume..");
+#endif
+	pthread_mutex_lock(&pool->condmutex);  // Lock the conditional
+	pool->suspend = 0; // Reset the state
+#ifdef DEBUG
+	printf("\n[THREADPOOL:RESM:INFO] Waking up all threads..");
+#endif
+	pthread_cond_broadcast(&pool->conditional); // Wake up all threads
+	pthread_mutex_unlock(&pool->condmutex); // Release the mutex
+#ifdef DEBUG
+	printf("\n[THREADPOOL:RESM:INFO] Resume complete!");
+#endif
+}
+
+/* Returns number of pending jobs in the pool. See
+ * header for more details
+ */
+uint64_t getJobCount(ThreadPool *pool){
+	return atomic64_read(&pool->jobCount);
+}
+
+/* Returns the number of threads in the pool. See
+ * header for more details.
+ */
+uint64_t getThreadCount(ThreadPool *pool){
+	return pool->numThreads;
+}
+
+/* Destroy the pool. See header for more details.
+ *
+ */
+void destroyPool(ThreadPool *pool){
+	if(pool==NULL || !pool->isInitialized){ // Sanity check
+		printf("\n[THREADPOOL:EXIT:ERROR] Pool is not initialized!");
+		return;
+	}
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXIT:INFO] Trying to wakeup all waiting threads..");
+#endif
+	atomic_set(&pool->run, 0); // Stop the pool
+
+	pthread_mutex_lock(&pool->condmutex);
+	pthread_cond_broadcast(&pool->conditional); // Wake up all idle threads
+	pthread_mutex_unlock(&pool->condmutex);
+
+	int rc;
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXIT:INFO] Waiting for all threads to exit..");
+#endif
+
+	ThreadList *list = pool->threads, *backup = NULL; // For travsersal
+
+	uint64_t i = 0;
+	while(list != NULL){
+
+#ifdef DEBUG
+		printf("\n[THREADPOOL:EXIT:INFO] Joining thread %" PRIu64 "..", i);
+#endif
+
+		rc = pthread_join(list->thread, NULL); //  Wait for ith thread to join
+		if(rc)
+			printf("\n[THREADPOOL:EXIT:WARNING] Unable to join THREAD%" PRIu64 "!", i);
+
+#ifdef DEBUG		
+		else
+			printf("\n[THREADPOOL:EXIT:INFO] THREAD%" PRIu64 " joined!", i);
+#endif
+
+		backup = list;
+		list = list->next; // Continue
+
+#ifdef DEBUG
+		printf("\n[THREADPOOL:EXIT:INFO] Releasing memory for THREAD%" PRIu64 "..", i);
+#endif
+
+		free(backup); // Free ith thread
+		i++;
+	}
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXIT:INFO] Destroying remaining jobs..");
+#endif
+
+	// Delete remaining jobs
+	while(pool->FRONT!=NULL){
+		Job *j = pool->FRONT;
+		pool->FRONT = pool->FRONT->next;
+		free(j);
+	}
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXIT:INFO] Destroying conditionals..");
+#endif
+	rc = pthread_cond_destroy(&pool->conditional); // Destroying idle conditional
+	rc = pthread_cond_destroy(&pool->endconditional); // Destroying end conditional
+	if(rc)
+		printf("\n[THREADPOOL:EXIT:WARNING] Unable to destroy one or more conditionals (error code %d)!", rc);
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXIT:INFO] Destroying the mutexes..");
+#endif
+
+	rc = pthread_mutex_destroy(&pool->queuemutex); // Destroying queue lock
+	rc = pthread_mutex_destroy(&pool->condmutex); // Destroying idle lock
+	rc = pthread_mutex_destroy(&pool->endmutex); // Destroying end lock
+	if(rc)
+		printf("\n[THREADPOOL:EXIT:WARNING] Unable to destroy one or mutexes (error code %d)!", rc);
+
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXIT:INFO] Releasing memory for the pool..");
+#endif
+
+	free(pool); // Release the pool
+#ifdef DEBUG
+	printf("\n[THREADPOOL:EXIT:INFO] Pool destruction completed!");
+#endif
+}

--- a/sideloader/offload_proxy/offload_thread_pool.c
+++ b/sideloader/offload_proxy/offload_thread_pool.c
@@ -461,11 +461,7 @@ void suspend_pool(thread_pool_t *pool){
 /* Resume a suspended pool. See header for more
  * details.
  */
-<<<<<<< HEAD
 void resume_pool(thread_pool_t *pool){
-=======
-void resumePool(thread_pool_t *pool){
->>>>>>> fdb55f0c5a2912199e7add48bd7698f493a7f7f0
 	if(pool==NULL || !pool->is_initialized){ // Sanity check
 		printf("\n[THREADPOOL:RESM:ERROR] Pool is not initialized!");
 		return;

--- a/sideloader/offload_proxy/offload_thread_pool.h
+++ b/sideloader/offload_proxy/offload_thread_pool.h
@@ -1,0 +1,323 @@
+/*   MyThreads : A small, efficient, and fast threadpool implementation in C
+ *   Copyright (C) 2017  Subhranil Mukherjee (https://github.com/iamsubhranil)
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 3 of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MYTHREADS_H
+#define MYTHREADS_H
+
+#include <stdint.h> // Standard integer
+#include <pthread.h> // The thread library
+#include <stdio.h> // Standard output functions in case of errors and debug
+#include <stdlib.h> // Memory management functions
+#include <inttypes.h> // Standard integer format specifiers
+
+#include "atomic.h"
+
+//#define DEBUG // The debug switch
+
+/* The main pool structure
+ * 
+ * To find member descriptions, see mythreads.c .
+ */
+
+
+/* A singly linked list of threads. This list
+ * gives tremendous flexibility managing the 
+ * threads at runtime.
+ */
+typedef struct ThreadList {
+	pthread_t thread; // The thread object
+	struct ThreadList *next; // Link to next thread
+} ThreadList;
+
+/* A singly linked list of worker functions. This
+ * list is implemented as a queue to manage the
+ * execution in the pool.
+ */
+typedef struct Job {
+	void (*function)(void *); // The worker function
+	void *args; // Argument to the function
+	struct Job *next; // Link to next Job
+} Job;
+
+/* The core pool structure. This is the only
+ * user accessible structure in the API. It contains
+ * all the primitives necessary to provide
+ * synchronization between the threads, along with
+ * dynamic management and execution control.
+ */
+struct ThreadPool {
+	/* The FRONT of the thread queue in the pool.
+	 * It typically points to the first thread
+	 * created in the pool.
+	 */
+	ThreadList * threads;
+
+	/* The REAR of the thread queue in the pool.
+	 * Points to the last, and most young thread
+	 * added to the pool.
+	 */
+	ThreadList * rearThreads;
+
+	/* Number of threads in the pool. As this can
+	 * grow dynamically, access and modification 
+	 * of it is bounded by a mutex.
+	 */
+	uint64_t numThreads;
+
+	/* The indicator which indicates the number
+	 * of threads to remove. If this is equal to
+	 * N, then N threads will be removed from the
+	 * pool when they are idle. All threads
+	 * typically check the value of this variable
+	 * before executing a job, and if finds the 
+	 * value >0, immediately exits.
+	 */
+	uint64_t removeThreads;
+
+	/* Denotes the number of idle threads in the
+	 * pool at any given instant of time. This value
+	 * is used to check if all threads are idle,
+	 * and thus triggering the end of job queue or
+	 * the initialization of the pool, whichever
+	 * applicable.
+	 */
+	volatile uint64_t waitingThreads;
+
+	/* Denotes whether the pool is presently
+	 * initalized or not. This variable is used to
+	 * busy wait after the creation of the pool
+	 * to ensure all threads are in waiting state.
+	 */
+	volatile uint8_t isInitialized;
+
+	/* The main mutex for the job queue. All
+	 * operations on the queue is done after locking
+	 * this mutex to ensure consistency.
+	 */
+	pthread_mutex_t queuemutex;
+
+	/* This mutex indicates whether a thread is
+	 * presently in idle state or not, and is used
+	 * in conjunction with the conditional below.
+	 */
+	pthread_mutex_t condmutex;
+
+	/* Conditional to ensure conditional wait.
+	 * When idle, each thread waits on this 
+	 * conditional, which is signaled by various
+	 * methods to indicate the wake of the thread.
+	 */
+	pthread_cond_t conditional;
+
+	/* Ensures pool state. When the pool is running,
+	 * this is set to 1. All the threads loop on
+	 * this condition, and exits immediately when
+	 * it is set to 0, which happens when the pool
+	 * is destroyed.
+	 */
+//	_Atomic uint8_t run;
+	atomic_t run;
+
+	/* Used to assign unique thread IDs to each
+	 * running threads. It is an always incremental
+	 * counter.
+	 */
+	uint64_t threadID;
+
+	/* The FRONT of the job queue, which typically
+	 * points to the job to be executed next.
+	 */
+	Job *FRONT;
+
+	/* The REAR of the job queue, which points
+	 * to the job last added in the pool.
+	 */
+	Job *REAR;
+
+	/* Mutex used to denote the end of the job
+	 * queue, which triggers the function
+	 * waitForComplete.
+	 */
+	pthread_mutex_t endmutex;
+
+	/* Conditional to signal the end of the job
+	 * queue.
+	 */
+	pthread_cond_t endconditional;
+	
+	/* Variable to impose and withdraw
+	 * the suspend state.
+	 */
+	uint8_t suspend;
+
+	/* Counter to the number of jobs
+	 * present in the job queue
+	 */
+//	_Atomic uint64_t jobCount;
+	atomic64_t jobCount;
+};
+
+typedef struct ThreadPool ThreadPool;
+
+/* The status enum to indicate any failure.
+ * 
+ * These values can be compared to all the functions
+ * that returns an integer, to findout the status of
+ * the execution of the function.
+ */
+typedef enum Status{
+	MEMORY_UNAVAILABLE,
+	QUEUE_LOCK_FAILED,
+	QUEUE_UNLOCK_FAILED,
+	SIGNALLING_FAILED,
+	BROADCASTING_FAILED,
+	COND_WAIT_FAILED,
+	THREAD_CREATION_FAILED,
+	POOL_NOT_INITIALIZED,
+	POOL_STOPPED,
+	INVALID_NUMBER,
+	WAIT_ISSUED,
+	COMPLETED	
+} ThreadPoolStatus;
+
+/* Creates a new thread pool with argument number of threads. 
+ * 
+ * When this method returns, and if the return value is not 
+ * NULL, it is assured that all threads are initialized and 
+ * in waiting state. If any thread fails to initialize, 
+ * typically if the pthread_create method fails, a warning 
+ * message is print on the stdout. This method also can fail
+ * in case of insufficient memory, which is rare, and a NULL
+ * is returned in that case.
+ */
+ThreadPool * createPool(uint64_t);
+
+/* Waits till all the threads in the pool are finished.
+ *
+ * When this method returns, it is assured that all threads
+ * in the pool have finished executing, and in waiting state.
+ */
+void waitToComplete(ThreadPool *);
+
+/* Destroys the argument pool.
+ *
+ * This method tries to stop all threads in the pool
+ * immediately, and destroys any resource that the pool has
+ * used in its lifetime. However, this method will not
+ * return until all threads have finished processing their
+ * present work. That is, this method will not halt any
+ * actively executing thread. Rather, it'll wait for the
+ * present jobs to complete, and will keep the threads from
+ * running any new jobs. This method then joins all the
+ * threads, destroys all synchronization objects, and frees
+ * any remaining jobs, finally freeing the pool itself.
+ */
+void destroyPool(ThreadPool *);
+
+/* Add a new job to the pool.
+ *
+ * This method adds a new job, that is a worker function,
+ * to the pool. The execution of the function is performed
+ * asynchronously, however. This method only assures the
+ * addition of the job to the job queue. The job queue is
+ * ordered in FIFO style, i.e., for this job to execute,
+ * all the jobs that has been added previously has to be
+ * executed first. This method doesn't guarantee the thread
+ * on which the job may execute. Rather, when its turn comes,
+ * the thread which first becomes idle, executes this job.
+ * When all threads are idle, any one of them wakes up and
+ * executes this function asynchronously.
+ */
+ThreadPoolStatus addJobToPool(ThreadPool *, void (*func)(void *), void *);
+
+/* Add some new threads to the pool.
+ * 
+ * This function adds specified number of new threads to the 
+ * argument threadpool. When this function returns, it is 
+ * ensured that a new thread has been added to the pool. 
+ * However, this new thread will only come to effect if there 
+ * are remainder jobs, that is the job queue is not presently 
+ * empty. This new thread will not steal any running jobs 
+ * from the running threads. Occasionally, this method will 
+ * return some error codes, typically due to the failure of 
+ * pthread_create, or for insufficient memory. These error 
+ * codes can be compared using the Status enum above.
+ */
+ThreadPoolStatus addThreadsToPool(ThreadPool *, uint64_t);
+
+/* Suspend all currently executing threads in the pool.
+ *
+ * This method pauses all currently executing threads in
+ * the pool. When the method call returns, it is guaranteed
+ * that all threads have been suspended at appropiate
+ * breakpoints. However, if a thread is presently executing,
+ * it is not forcefully suspended. Rather, the call waits
+ * till the thread completes the present job, and then
+ * halts the thread.
+ */
+void suspendPool(ThreadPool *);
+
+/* Resume a suspended pool.
+ *
+ * This method resumes a pool, aynchronously, if and only 
+ * if the pool was suspended before. When the method returns,
+ * it is guaranteed the all the threads of the pool will
+ * wake up from suspend very soon in future. This method 
+ * fails if the pool was not previously suspended.
+ */
+void resumePool(ThreadPool *);
+
+/* Remove an existing thread from the pool.
+ *
+ * This function will remove one thread from the threadpool,
+ * asynchronously. That is, this method will not stop any
+ * active threads, rather it'll merely indicate the wish.
+ * When any active thread will become idle, before becoming
+ * active again the thread will check if removal is wished.
+ * If it is wished, then thread will immediately exit. This
+ * method can run N times to remove N threads, however it
+ * has some serious consequences. If N is greater than the
+ * number of threads present in the pool, say M, then all
+ * M threads will be stopped. However, next (N-M) threads
+ * will also immediately exit when added to the pool. If
+ * all M threads are removed from the queue, then the job
+ * queue will halt, and when a new thread will be added to
+ * the pool, the queue will automatically resume from the
+ * position where it stopped.
+ */
+void removeThreadFromPool(ThreadPool *);
+
+/* Returns the number of pending jobs in the pool.
+ *
+ * This method returns the number of pending jobs in the 
+ * pool, at the instant of the issue of this call. This 
+ * denotes the number of jobs the pool will  finish before 
+ * idlement if no new jobs are added to the pool from this
+ * instant.
+ */
+uint64_t getJobCount(ThreadPool *pool);
+
+/* Returns the number of threads present in the pool.
+ *
+ * The number returned by this method is aware of all
+ * thread addition and removal calls. Hence only the number 
+ * of threads that are "active" in the pool, either by 
+ * executing a worker function or in idle wait, will be
+ * returned by this method.
+ */
+uint64_t getThreadCount(ThreadPool *);
+
+#endif

--- a/sideloader/offload_proxy/offload_thread_pool.h
+++ b/sideloader/offload_proxy/offload_thread_pool.h
@@ -14,8 +14,8 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MYTHREADS_H
-#define MYTHREADS_H
+#ifndef OFFLOAD_THREAD_POOL_H
+#define OFFLOAD_THREAD_POOL_H
 
 #include <stdint.h> // Standard integer
 #include <pthread.h> // The thread library
@@ -328,4 +328,4 @@ uint64_t get_job_count(thread_pool_t *pool);
  */
 uint64_t get_thread_count(thread_pool_t *);
 
-#endif
+#endif /* OFFLOAD_THREAD_POOL_H */


### PR DESCRIPTION
#118 
Add thread pool functions in offload proxy and schedule_to() function to increase IO offload speed.
-add ./sideload/offload_proxy/offload_thread_pool.c/h
-modify ./sideload/offload_proxy/offload_local_proxy.c
-modify ./sideload/offload_proxy/offload_fio.c/h
-modify ./sideload/offload_proxy/offload_network.c/h
-modify ./kernel/thread.c/h
-modify ./kerenel/offload/offload_message.c/h