### PR TITLE
Fix Permission denied error when AIM7 runs with IO offload.

### DIFF
--- a/sideloader/offload_proxy/offload_mmap.h
+++ b/sideloader/offload_proxy/offload_mmap.h
@@ -6,7 +6,7 @@
 #define OFFLOAD_MAGIC           (0x5D4C3B2A)
 
 int mmap_channels(channel_t *offload_channels, int n_nodes, int n_offload_channels, int opages, int ipages);
-int munmap_channels(channel_t *offload_channels, int n_offload_channels);
+int munmap_channels(void);
 unsigned long mmap_unikernels_memory(int n_nodes);
 unsigned long get_va(unsigned long pa);
 unsigned long get_pa_base(void);

--- a/sideloader/offload_proxy/offload_thread_pool.h
+++ b/sideloader/offload_proxy/offload_thread_pool.h
@@ -44,16 +44,6 @@ typedef struct threadList {
 	struct threadList *next; // Link to next thread
 } thread_list_t;
 
-/* A singly linked list of worker functions. This
- * list is implemented as a queue to manage the
- * execution in the pool.
- */
-typedef struct Job {
-	void (*function)(void *); // The worker function
-	void *args; // Argument to the function
-	struct Job *next; // Link to next Job
-} job_t;
-
 /* 
  * the args for the worker function
  */
@@ -61,6 +51,18 @@ typedef struct JobArgs {
    channel_t *ch;
    io_packet_t pkt;
 } job_args_t;
+
+/* A singly linked list of worker functions. This
+ * list is implemented as a queue to manage the
+ * execution in the pool.
+ */
+typedef struct Job {
+	void (*function)(void *); // The worker function
+	//void *args; // Argument to the function
+	job_args_t args[1]; // Argument to the function
+	struct Job *next; // Link to next Job
+} job_t;
+
 
 /* The core pool structure. This is the only
  * user accessible structure in the API. It contains


### PR DESCRIPTION
#128 
-  thread pool function's parameter is contaminated when a thread references the parameter which is still used by other thread.
- change the method to send thread pool function's parameter. It used pointer to the parameter but changed to copy the parameter.
- mmap the whole cq area but each cq.