### PR TITLE
Add IPC functions based on shared memory

### DIFF
--- a/application/shm/Makefile
+++ b/application/shm/Makefile
@@ -1,0 +1,29 @@
+.PHONY: all clean
+
+ifeq ($(TARGET),)
+  TARGET = knl
+endif
+
+UKDIR = ../..
+LIB_DIR = $(UKDIR)/library
+APP_DIR = ..
+NEWLIB_DIR = /opt/hermit/x86_64-hermit
+
+CSOURCEFILES = $(wildcard *.c) 
+COBJECTFILES = $(notdir $(patsubst %.c,%.o,$(CSOURCEFILES)))
+
+INCS = -I$(UKDIR)/include/$(TARGET) -I$(UKDIR)/include/api -I$(LIB_DIR) 
+
+CC=gcc
+LD=ld
+CFLAGS=-c -m64 -Wall -mcmodel=large -fno-common -g -l$(LIB_DIR) -fno-stack-protector
+
+LD = ${CROSS_COMPILE}ld 
+
+all: ${COBJECTFILES}
+%.o: %.c
+	${CC} ${CFLAGS} ${INCS} -o $*.o $<
+	${LD} -o uapp.elf -e main $*.o $(NEWLIB_DIR)/lib/libpthread.a ${NEWLIB_DIR}/lib/libc.a ${LIB_DIR}/*.o 
+
+clean:
+	rm -f *.elf *.o tags

--- a/application/shm/shm.c
+++ b/application/shm/shm.c
@@ -1,0 +1,137 @@
+#include <stdio.h>      // printf()
+#include <unistd.h>     // sleep()
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+#include "syscall.h"
+
+#define  KEY_NUM     9534
+#define  KEY_NUM2    8534
+#define  MEM_SIZE    1024
+
+#define	shmget	sys_shmget
+#define	shmat	sys_shmat
+#define	shmdt	sys_shmdt
+#define	shmctl	sys_shmctl
+#define	sleep	sys_msleep
+
+int f1( void)
+{
+  int   shm_id[10];
+  void *shm_addr[10];
+  int i = 0;
+
+  printf("f1 start: \n");
+
+  for(i = 0; i < 2; i++) {
+    if((shm_id[i] = shmget(KEY_NUM+i, MEM_SIZE, IPC_CREAT|0666)) == -1)
+    {
+      printf( "공유 메모리 생성 실패\n");
+      return -1;
+    }
+    printf( "공유 메모리 생성shmid = %d\n", shm_id[i]);
+
+    if(( void *)-1 == (shm_addr[i] = shmat( shm_id[i], ( void *)0, 0)))
+    {
+      printf( "공유 메모리 첨부 실패\n");
+      return -1;
+    }
+    printf( "공유 메모리 첨부shmid = %d, shm_addr %lx\n\n", shm_id[i], (unsigned long) shm_addr[i]);
+  }
+  printf("\n");
+
+  for(i = 0; i < 2; i++) {
+    if(-1 == shmdt(shm_addr[i]))
+    {
+      printf( "공유 메모리 분리 실패\n");
+      return -1;
+    }
+    else
+    {
+      printf( "공유 메모리 분리shm addr = %lx \n", (unsigned long) shm_addr[i]);    // 공유 메모리를 화면에 출력
+    }
+
+    if(shmctl(shm_id[i], IPC_RMID, 0) == -1) {
+      printf( "공유 메모리 삭제 실패\n");
+    }
+    else
+    {
+      printf( "공유 메모리 삭제shm id = %d \n\n", shm_id[i]);    // 공유 메모리를 화면에 출력
+    }
+  }
+
+  return 0;
+}
+
+int f2( void)
+{
+  int   shm_id;
+  void *shm_addr;
+
+  printf("f2 start: \n");
+
+  if((shm_id = shmget(KEY_NUM2, MEM_SIZE, IPC_CREAT|0666)) == -1)
+  {
+    printf( "공유 메모리 생성 실패\n");
+    return -1;
+  }
+
+
+  if ((void *)-1 == (shm_addr = shmat( shm_id, ( void *)0, 0)))
+  {
+    printf( "공유 메모리 첨부 실패\n");
+    return -1;
+  }
+
+  while( 1 )
+  {
+    sprintf((char *)shm_addr, "%d", 99);       // 공유 메모리에 카운터 출력
+    sleep(1);
+  }
+
+  return 0;
+}
+
+int f3( void)
+{
+  int   shm_id;
+  void *shm_addr;
+
+  printf("f3 start: \n");
+
+  if((shm_id = shmget(KEY_NUM2, MEM_SIZE, IPC_CREAT|0666)) == -1)
+  {
+    printf( "공유 메모리 생성 실패\n");
+    return -1;
+  }
+
+  if(( void *)-1 == (shm_addr = shmat(shm_id, (void *)0, 0)))
+  {
+     printf( "공유 메모리 첨부 실패\n");
+     return -1;
+  }
+
+  while( 1 )
+  {
+     printf( "\rshm addr: %lx value : %s", (unsigned long) shm_addr, (char *)shm_addr);    // 공유 메모리를 화면에 출력
+     sleep( 1);
+  }
+
+  return 0;
+}
+
+
+
+int main()
+{
+  printf("f1 create: \n");
+  create_thread((QWORD)f1, 0, -1);
+
+  printf("f2 create: \n");
+  create_thread((QWORD)f2, 0, -1);
+
+  printf("f3 create: \n");
+  create_thread((QWORD)f3, 0, -1);
+
+  return 0;
+}

--- a/include/api/sys/ipc.h
+++ b/include/api/sys/ipc.h
@@ -1,0 +1,113 @@
+/****************************************************************************
+ * include/sys/ipc.h
+ *
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SYS_IPC_H
+#define __INCLUDE_SYS_IPC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+//#include <nuttx/config.h>
+
+#include <sys/types.h>
+
+/****************************************************************************
+ * Pre-Processor Definitions
+ ****************************************************************************/
+
+/* Mode bits:  The lower order 9-bit bits are the standard mode bits */
+
+#define IPC_MODE    0x01ff     /* Mode bit mask */
+#define IPC_CREAT   (1 << 10)  /* Create entry if key does not exist */
+#define IPC_EXCL    (1 << 11)  /* Fail if key exists */
+#define IPC_NOWAIT  (1 << 12)  /* Error if request must wait */
+
+/* Keys: */
+
+#define IPC_PRIVATE 0     /* Private key */
+
+/* Control commands: */
+
+#define IPC_RMID    0    /* Remove identifier */
+#define IPC_SET     1    /* Set options */
+#define IPC_STAT    2    /* Get options */
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/* The ipc_perm structure is used by three mechanisms for XSI interprocess
+ * communication (IPC): messages, semaphores, and shared memory. All use a
+ * common structure type, ipc_perm, to pass information used in determining
+ * permission to perform an IPC operation.
+ */
+
+struct ipc_perm
+{
+#if 0 /* User and group IDs not yet supported by NuttX */
+  uid_t  uid;    /* Owner's user ID */
+  gid_t  gid;    /* Owner's group ID */
+  uid_t  cuid;   /* Creator's user ID */
+  gid_t  cgid;   /* Creator's group ID */
+#endif
+  mode_t mode;   /* Read/write permission */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+//key_t ftok(FAR const char *path, int id);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __INCLUDE_SYS_IPC_H */

--- a/include/api/sys/shm.h
+++ b/include/api/sys/shm.h
@@ -1,0 +1,114 @@
+/****************************************************************************
+ * include/sys/shm.h
+ *
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SYS_SHM_H
+#define __INCLUDE_SYS_SHM_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+//#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <time.h>
+
+/****************************************************************************
+ * Pre-Processor Definitions
+ ****************************************************************************/
+/* Definitions required by POSIX */
+
+#define SHM_RDONLY 0x01 /* Attach read-only (else read-write) */
+#define SHM_RND    0x02 /* Round attach address to SHMLBA */
+
+/* Segment low boundary address multiple */
+
+#ifdef CONFIG_SHM_SHMLBA
+#  define SHMLBA CONFIG_SHM_SHMLBA
+#else
+#  define SHMLBA 0x0
+#endif
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/* Unsigned integer used for the number of current attaches that must be
+ * able to store values at least as large as a type unsigned short.
+ */
+
+typedef unsigned short shmatt_t;
+
+struct shmid_ds
+{
+  struct ipc_perm shm_perm;   /* Operation permission structure */
+  size_t          shm_segsz;  /* Size of segment in bytes */
+  pid_t           shm_lpid;   /* Process ID of last shared memory operation */
+  pid_t           shm_cpid;   /* Process ID of creator */
+  shmatt_t        shm_nattch; /* Number of current attaches */
+  time_t          shm_atime;  /* Time of last shmat() */
+  time_t          shm_dtime;  /* Time of last shmdt() */
+  time_t          shm_ctime;  /* Time of last change by shmctl() */
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+void *shmat(int shmid, const void *shmaddr, int shmflg);
+int shmctl(int shmid, int cmd, struct shmid_ds *buf);
+int shmdt(const void *shmaddr);
+int shmget(key_t key, size_t size, int shmflg);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __INCLUDE_SYS_SHM_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -3,7 +3,7 @@ ifeq ($(TARGET),)
 endif
 
 TEXT_BASE64=0xFFFF8000C0300000
-INCLUDES=-I. -Ioffload -Iconsole -Isystemcall -I../include/$(TARGET) -I../include/api 
+INCLUDES=-I. -Ioffload -Iconsole -Ishm -Isystemcall -I../include/$(TARGET) -I../include/api 
 CFLAG=-m64 -mno-red-zone -nostdlib -ffreestanding -Wall -mcmodel=large -g
 CFLAG+=-mno-mmx -mno-3dnow -mno-avx
 CFLAG+=-fomit-frame-pointer -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables -DVCONSOLE -O0 -D_$(TARGET)_
@@ -18,7 +18,7 @@ AFLAG=-D__ASSEMBLY__
 ENTRYPOINTSOURCEFILE=entrypoint.S
 ENTRYPOINTOBJECTFILE=entrypoint.o
 
-CSOURCEFILES=$(patsubst %_32.c, ,$(wildcard *.c) $(wildcard ./offload/*.c) $(wildcard ./console/*.c) $(wildcard ./systemcall/*.c))
+CSOURCEFILES=$(patsubst %_32.c, ,$(wildcard *.c) $(wildcard ./offload/*.c) $(wildcard ./console/*.c) $(wildcard ./shm/*.c) $(wildcard ./systemcall/*.c))
 ASSEMBLYSOURCEFILES=$(patsubst %_32.S, ,$(wildcard *.S))
 COBJECTFILES=$(notdir $(patsubst %.c,%.o,$(CSOURCEFILES)))
 ASSEMBLYOBJECTFILES=$(notdir $(patsubst %.S,%.o,$(ASSEMBLYSOURCEFILES)))
@@ -54,6 +54,7 @@ $(ENTRYPOINTOBJECTFILE): $(ENTRYPOINTSOURCEFILE)
 prepare:
 	make -C offload
 	make -C console 
+	make -C shm 
 	make -C systemcall
 
 clean:
@@ -61,6 +62,7 @@ clean:
 	make -f Makefile_32 clean
 	make -C offload clean
 	make -C console clean
+	make -C shm clean
 	make -C systemcall clean
 
 ifeq (Dependency.dep, $(wildcard Dependency.dep))

--- a/kernel/shm/Makefile
+++ b/kernel/shm/Makefile
@@ -1,0 +1,29 @@
+.PHONY: all clean
+
+ifeq ($(TARGET),)
+        TARGET=knl
+endif
+
+UKDIR=../..
+
+INCS=-I. -I.. -I../console -I$(UKDIR)/include/api -I$(UKDIR)/include/$(TARGET)
+CFLAGS=-m64 -mno-red-zone -nostdlib -ffreestanding -Wall -mcmodel=large -g 
+CFLAGS+=-mno-mmx -mno-3dnow -mno-avx
+CFLAGS+=-fno-common -fomit-frame-pointer -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables -DVCONSOLE -O3 -D_$(TARGET)_
+
+GCC64=gcc
+
+CSOURCEFILES=$(wildcard *.c)
+COBJECTFILES=$(notdir $(patsubst %.c,%.o,$(CSOURCEFILES)))
+
+all: $(COBJECTFILES)
+	cp *.o ..
+
+%.o: %.c
+	$(GCC64) $(CFLAGS) $(INCS) -c $<
+
+clean:
+	rm -f *.o
+
+
+

--- a/kernel/shm/shm.h
+++ b/kernel/shm/shm.h
@@ -1,0 +1,140 @@
+/****************************************************************************
+ * mm/shm/shm.h
+ *
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __MM_SHM_SHM_H
+#define __MM_SHM_SHM_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <sys/lock.h>
+
+#include "shm_mm.h"
+
+//#define DEBUG
+
+#define	CONFIG_ARCH_SHM_MAXREGIONS	1024	
+#define	CONFIG_ARCH_SHM_SR_DATA_SIZE	(0x1000 * 24)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+/* Bit definitions for the struct shm_region_s sr_flags field */
+
+#define SRFLAG_AVAILABLE 0        /* Available if no flag bits set */
+#define SRFLAG_INUSE     (1 << 0) /* Bit 0: Region is in use */
+#define SRFLAG_UNLINKED  (1 << 1) /* Bit 1: Region perists while references */
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* This structure represents the state of one shared memory region
+ * allocation.  Cast compatible with struct shmid_ds.
+ */
+
+struct shm_region_s
+{
+  struct shmid_ds sr_ds; /* Region info */
+  BOOL  sr_flags;        /* See SRFLAGS_* definitions */
+  key_t sr_key;          /* Lookup key */
+  spinlock_t sr_lock;    /* Manages exclusive access to this region */
+
+  /* pointer to IPC shared memory */
+  unsigned char *sr_data; // get from shm_alloc(), page alligned
+};
+
+/* This structure represents the set of all shared memory regions.
+ * Access to the region 
+ */
+
+struct shm_info_s
+{
+  unsigned long padding;
+  spinlock_t si_lock; 	/* Manages exclusive access to this region */
+  unsigned long padding2;
+  int shm_init_flag;
+  MM shm_free_mem_mgt;
+  struct shm_region_s si_region[CONFIG_ARCH_SHM_MAXREGIONS];
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* State of the all shared memory */
+
+extern struct shm_info_s *g_shminfo;
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: shm_destroy
+ *
+ * Description:
+ *   Destroy a memory region.  This function is called:
+ *
+ *   - On certain conditions when shmget() is not successful in instantiating
+ *     the full memory region and we need to clean up and free a table entry.
+ *   - When shmctl() is called with cmd == IPC_RMID and there are no
+ *     processes attached to the memory region.
+ *   - When shmdt() is called after the last process detaches from memory
+ *     region after it was previously marked for deletion by shmctl().
+ *
+ * Input Parameters:
+ *   shmid - Shared memory identifier
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumption:
+ *   The caller holds either the region table semaphore or else the
+ *   semaphore on the particular entry being deleted.
+ *
+ ****************************************************************************/
+
+void shm_destroy(int shmid);
+void shm_initialize(void);
+
+int shmget(key_t key, size_t size, int shmflg);
+void *shmat(int shmid, const void *shmaddr, int shmflg);
+int shmdt(const void *shmaddr);
+int shmctl(int shmid, int cmd, struct shmid_ds *buf);
+
+#endif /* __MM_SHM_SHM_H */

--- a/kernel/shm/shm_initialize.c
+++ b/kernel/shm/shm_initialize.c
@@ -1,0 +1,107 @@
+/****************************************************************************
+ * mm/shm/shm_initialize.c
+ *
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <sys/lock.h>
+
+#include "console_function.h"
+#include "memory_config.h"
+#include "shm.h"
+#include "utility.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* State of the all shared memory */
+struct shm_info_s *g_shminfo;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: shm_initialize
+ *
+ * Description:
+ *   Perform one time, start-up initialization of the shared memor logic.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void shm_initialize(void)
+{
+
+  g_shminfo = (struct shm_info_s *) SHM_INFO_S_VA;
+
+#ifdef DEBUG
+  cs_printf("shm_initialize(): shminfo addr = 0x%q \n", g_shminfo);
+#endif
+
+  struct shm_region_s *region;
+  int i;
+
+  //spinlock_init(&g_shminfo->si_lock);
+
+  /* Initialize each shared memory region */
+  for (i = 0; i < CONFIG_ARCH_SHM_MAXREGIONS; i++)
+  {
+    region = &g_shminfo->si_region[i];
+    lk_memset(region, 0, sizeof(struct shm_region_s));
+  }
+
+  /* Initialize shm free memory mgt */
+  lk_memset(&g_shminfo->shm_free_mem_mgt, 0, sizeof(MM));
+}
+

--- a/kernel/shm/shm_initialize.c
+++ b/kernel/shm/shm_initialize.c
@@ -41,6 +41,7 @@
 #include "console_function.h"
 #include "memory_config.h"
 #include "shm.h"
+#include "shm_mm_config.h"
 #include "utility.h"
 
 /****************************************************************************

--- a/kernel/shm/shm_mm.c
+++ b/kernel/shm/shm_mm.c
@@ -1,0 +1,466 @@
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include "shm.h"
+#include "utility.h"
+#include "console.h"
+#include "thread.h"
+#include "shm_mm.h"
+#include "console_function.h"
+
+#define DEBUG
+
+extern struct shm_info_s *g_shminfo;
+
+// pointer to the memory management structure for the shm free memory 
+MM *g_shm_free_mem_mgt;
+
+
+/**
+ *  Initialize free memory for shm
+ */
+void shm_free_mem_init(void)
+{
+  int i = 0, j = 0;
+  BYTE* cur_bitmap = NULL;
+  int block_count = 0, bitmap = 0;
+
+  g_shminfo = (struct shm_info_s *)SHM_INFO_S_VA;  
+  g_shm_free_mem_mgt = (MM *) &g_shminfo->shm_free_mem_mgt;
+
+#ifdef DEBUG
+  cs_printf("shm_mem_init(): sizeof(struct shm_info_s) 0x%q\n", sizeof(struct shm_info_s));
+  cs_printf("shm_mem_init(): PAGE_MIN_SIZE 0x%q\n", PAGE_MIN_SIZE);
+#endif
+
+  int shm_info_s_page_count = (int) (sizeof(struct shm_info_s) / PAGE_MIN_SIZE);
+  if((sizeof(struct shm_info_s) % PAGE_MIN_SIZE) > 0) {
+    shm_info_s_page_count++;
+  }
+
+  QWORD shm_free_mem_start = (QWORD) CONFIG_SHM_SHARED_MEMORY + (QWORD) (shm_info_s_page_count * PAGE_MIN_SIZE);  // shm free memory start addr
+  QWORD shm_free_mem_end = (QWORD) CONFIG_SHM_SHARED_MEMORY + (QWORD) CONFIG_SHM_SHARED_MEMORY_SIZE;  // shm free memory end addr 
+  QWORD shm_free_mem_size = shm_free_mem_end - shm_free_mem_start;	// shm free memory size
+
+#ifdef DEBUG
+  cs_printf("shm_mem_init(): CONFIG_SHM_SHARED_MEMORY       : 0x%q\n", CONFIG_SHM_SHARED_MEMORY);
+  cs_printf("shm_mem_init(): CONFIG_SHM_SHARED_MEMORY_SIZE  : 0x%q\n", CONFIG_SHM_SHARED_MEMORY_SIZE);
+  cs_printf("shm_mem_init(): shm_free_mem_start: 0x%q\n", shm_free_mem_start);
+  cs_printf("shm_mem_init(): shm_free_mem_end  : 0x%q\n", shm_free_mem_end);
+  cs_printf("shm_mem_init(): shm_free_mem_size : 0x%q\n", shm_free_mem_size);
+#endif
+
+  bitmap = shm_bitmap_size(shm_free_mem_size);	// bitmap size (block list index + bitmap address + bitmap)
+  bitmap = ((bitmap + (512 - 1)) & ~(512 - 1));
+
+  g_shm_free_mem_mgt->smallest_block = (shm_free_mem_size / PAGE_MIN_SIZE) - bitmap;
+
+  // calculate the max level of the block list
+  for (i=0; (g_shm_free_mem_mgt->smallest_block>>i) > 0; i++)
+    ;
+  g_shm_free_mem_mgt->max_level = i;
+
+  // Initialize the block list index areas to 0xFF
+  g_shm_free_mem_mgt->block_index = (BYTE*) shm_free_mem_start;
+
+  lk_memset(g_shm_free_mem_mgt->block_index, 0xFF, g_shm_free_mem_mgt->smallest_block * sizeof(BYTE));
+
+  // the base address of the bitmap
+  g_shm_free_mem_mgt->bitmap = (BITMAP*) (shm_free_mem_start + (sizeof(BYTE) * g_shm_free_mem_mgt->smallest_block));
+  // real address of bitmap
+  cur_bitmap = ((BYTE*) g_shm_free_mem_mgt->bitmap) + (sizeof(BITMAP) * g_shm_free_mem_mgt->max_level);
+
+  // Initialize the bitmap - set to 0x00 except the top level and trash block
+  for (j=0; j<g_shm_free_mem_mgt->max_level; j++) {
+    g_shm_free_mem_mgt->bitmap[j].bitmap = cur_bitmap;
+    g_shm_free_mem_mgt->bitmap[j].bitmap_count = 0;
+    block_count = g_shm_free_mem_mgt->smallest_block >> j;
+
+    // 8 blocks can be merged into upper level
+    for (i=0; i<block_count / 8; i++) {
+      *cur_bitmap = 0x00;
+      cur_bitmap++;
+    }
+
+    // if there is less than 8 the blocks area
+    if ((block_count % 8) != 0) {
+      *cur_bitmap = 0x00;
+      // if left block is odd number, it cannot be merged - trash block
+      i = block_count % 8;
+      if ((i % 2) == 1) {
+        *cur_bitmap |= (MM_TRUE << (i - 1));
+        g_shm_free_mem_mgt->bitmap[j].bitmap_count = 1;
+      }
+      cur_bitmap++;
+    }
+  }
+
+  // setting the start and end address of the block pool
+  g_shm_free_mem_mgt->start_addr = shm_free_mem_start + bitmap * PAGE_MIN_SIZE;
+  g_shm_free_mem_mgt->end_addr = shm_free_mem_end;
+  g_shm_free_mem_mgt->used_size = 0;
+
+  // Initialize spinlock for free memory management
+  spinlock_init(&(g_shm_free_mem_mgt->mm_spl));
+}
+
+/**
+ *  Allocate the input size memory
+ */
+void* shm_alloc(QWORD size)
+{
+  QWORD aligned_size = 0;
+  QWORD rel_address = 0;
+  long bl_offset = -1;
+  int array_offset = -1;
+  int bl_index = -1;
+  char *ret_addr = NULL;
+
+  g_shminfo = (struct shm_info_s *)SHM_INFO_S_VA;  
+  g_shm_free_mem_mgt = (MM *) &g_shminfo->shm_free_mem_mgt;
+
+  spinlock_lock(&(g_shm_free_mem_mgt->mm_spl));
+
+  aligned_size = shm_align_buddy_block(size);
+  if (aligned_size == 0) {
+     spinlock_unlock(&(g_shm_free_mem_mgt->mm_spl));
+    return 0;
+  }
+
+  // if not enough memory, return NULL
+  if (g_shm_free_mem_mgt->start_addr + g_shm_free_mem_mgt->used_size + aligned_size > g_shm_free_mem_mgt->end_addr) {
+    spinlock_unlock(&(g_shm_free_mem_mgt->mm_spl));
+    return 0;
+  }
+
+  // allocate buddy block and get index
+  bl_offset = shm_alloc_buddy_block(aligned_size);
+  if (bl_offset == -1) {
+    spinlock_unlock(&(g_shm_free_mem_mgt->mm_spl));
+    return 0;
+  }
+
+  bl_index = shm_block_list_index(aligned_size);
+
+  // save the block list index into the g_shm_free_mem_mgt->(It is used when deallocation)
+  rel_address = aligned_size * bl_offset;
+  array_offset = rel_address / PAGE_MIN_SIZE;
+
+  g_shm_free_mem_mgt->block_index[array_offset] = (BYTE) bl_index;
+  g_shm_free_mem_mgt->used_size += aligned_size;
+
+  ret_addr = (char*) (rel_address + g_shm_free_mem_mgt->start_addr);
+
+  // initialize the allocated memory to 0
+  lk_memset(ret_addr, 0, aligned_size);
+
+  spinlock_unlock(&(g_shm_free_mem_mgt->mm_spl));
+  return ret_addr;
+}
+
+
+/**
+ * free the input address' memory
+ *   - input: virtual address
+ */
+BOOL shm_free( void* address )
+{
+  QWORD rel_address = 0;
+  int array_offset = -1;
+  QWORD block_size = 0;
+  int block_list_index = -1;
+  int bitmap_offset = -1;
+
+  g_shminfo = (struct shm_info_s *)SHM_INFO_S_VA;  
+  g_shm_free_mem_mgt = (MM *) &g_shminfo->shm_free_mem_mgt;
+
+  spinlock_lock(&(g_shm_free_mem_mgt->mm_spl));
+
+  if (address == NULL) {
+    spinlock_unlock(&(g_shm_free_mem_mgt->mm_spl));
+    return FALSE;
+  }
+
+  // check thd assinged block size by converse the address
+  rel_address = ( ( QWORD ) address ) - g_shm_free_mem_mgt->start_addr;
+  array_offset = rel_address / PAGE_MIN_SIZE;
+
+  // if not assigned, return FALSE
+  if (g_shm_free_mem_mgt->block_index[array_offset] == 0xFF) {
+    spinlock_unlock(&(g_shm_free_mem_mgt->mm_spl));
+    return FALSE;
+  }
+
+  // initialize the index of the block list
+  // search the block list contained the assigned block
+  block_list_index = (int) g_shm_free_mem_mgt->block_index[array_offset];
+  g_shm_free_mem_mgt->block_index[array_offset] = 0xFF;
+
+  // count the assgined block size
+  block_size = PAGE_MIN_SIZE << block_list_index;
+
+  // free the block by the block offset in the block list
+  if(block_size == 0) return FALSE;
+  bitmap_offset = rel_address / block_size;
+  if (shm_free_buddy_block(block_list_index, bitmap_offset) == TRUE) {
+    g_shm_free_mem_mgt->used_size -= block_size;
+
+    spinlock_unlock(&(g_shm_free_mem_mgt->mm_spl));
+    return TRUE;
+  }
+
+  spinlock_unlock(&(g_shm_free_mem_mgt->mm_spl));
+  return FALSE;
+}
+
+
+/**
+ * Calculate the necessary space for saving metadata of free memory
+ */
+int shm_bitmap_size(QWORD free_mem_size)
+{
+  long smallest_block_size = 0;
+  DWORD block_index = 0;
+  DWORD bitmap_size = 0;
+  long i = 0;
+
+  // smallest block size
+  smallest_block_size = free_mem_size / PAGE_MIN_SIZE;
+  // count the required spce for the index of the block list
+  block_index = smallest_block_size * sizeof(BYTE);
+
+  // calculate the necessary space for bitmap
+  bitmap_size = 0;
+  for (i=0; (smallest_block_size >> i) > 0; i++) {
+    // for bitmap structure
+    bitmap_size += sizeof( BITMAP );
+    // for block list
+    bitmap_size += ((smallest_block_size >> i) + 7) / 8;
+  }
+
+  // return the required mem size for bitmap
+  return (block_index + bitmap_size + PAGE_MIN_SIZE - 1) / PAGE_MIN_SIZE;
+}
+
+
+/**
+ * Buddy block allocation
+ */
+int shm_alloc_buddy_block(QWORD aligned_size)
+{
+  int bl_index = -1, free_offset = -1;
+  int i = 0;
+
+  // get block list index satisfied required block size
+  bl_index = shm_block_list_index(aligned_size);
+  if (bl_index == -1)
+    return -1;
+
+//  spinlock_lock(&(g_free_memory.mm_spl));
+
+  // find the block until found from bl_index to max_level
+  for (i=bl_index; i<g_shm_free_mem_mgt->max_level; i++) {
+
+     // check the bitmap of the block list
+    free_offset = shm_find_free_block(i);
+    if (free_offset != -1)
+      break;
+  }
+
+  // if not fount, fail
+  if (free_offset == -1) {
+//    spinlock_unlock(&(g_free_memory.mm_spl));
+
+    return -1;
+  }
+
+  // if found, set flag in bitmap
+  shm_set_bitmap_flag(i, free_offset, MM_FALSE);
+
+  // if the block is found in upper block, split it
+  // set the left block empty and the right block exist, from i to bl_index
+  if (i > bl_index) {
+
+    for (i=i-1; i>=bl_index; i--) {
+      // set the left block empty
+      shm_set_bitmap_flag(i, free_offset * 2, MM_FALSE);
+      // set the rignt block exist
+      shm_set_bitmap_flag(i, free_offset * 2 + 1, MM_TRUE);
+      // split the left block again
+      free_offset = free_offset * 2;
+    }
+  }
+
+//  spinlock_unlock(&(g_free_memory.mm_spl));
+
+  return free_offset;
+}
+
+
+/**
+ * Return the close buddy block size
+ */
+QWORD shm_align_buddy_block(QWORD size)
+{
+  long i = 0;
+
+  for (i=0; i<g_shm_free_mem_mgt->max_level; i++) {
+    if (size <= (PAGE_MIN_SIZE << i))
+      return (PAGE_MIN_SIZE << i);
+  }
+
+  return 0;
+}
+
+/**
+ * Return the block list index closed to the aligned_size 
+ */
+int shm_block_list_index(QWORD aligned_size)
+{
+  int i = 0;
+
+  for (i=0; i<g_shm_free_mem_mgt->max_level; i++)
+    if (aligned_size <= (PAGE_MIN_SIZE << i))
+      return i;
+
+  return -1;
+}
+
+/**
+ * Search the bitmap of the block list
+ * if found, return the offset of the block
+ */
+int shm_find_free_block(int block_list_index)
+{
+  int i = 0, max_count = 0;
+  BYTE* ptr_bitmap = NULL;
+  QWORD* bitmap64 = NULL;
+
+  // if no data in the bitmap, return -1
+  if (g_shm_free_mem_mgt->bitmap[block_list_index].bitmap_count == 0)
+    return -1;
+
+  // Count the total number of the block in the block list, the check the bitmap
+  max_count = g_shm_free_mem_mgt->smallest_block >> block_list_index;
+  ptr_bitmap = g_shm_free_mem_mgt->bitmap[block_list_index].bitmap;
+
+  for (i=0; i<max_count; ) {
+    // check whether the bit set by 64 bits (QWORD = 8*8 bits)
+    if (((max_count - i) / 64) > 0) {
+      bitmap64 = (QWORD*) &(ptr_bitmap[i / 8]);
+
+      // if all is set 0, exclude them
+      if (*bitmap64 == 0) {
+        i += 64;
+        continue;
+      }
+    }
+
+    if ((ptr_bitmap[i / 8] & (MM_TRUE << (i % 8))) != 0)
+      return i;
+
+    i++;
+  }
+  return -1;
+}
+
+
+/**
+ * Free buddy block
+ */
+BOOL shm_free_buddy_block(int block_list_index, int block_offset)
+{
+  int buddy_block_offset = -1;
+  int i = 0;
+  BOOL flag = FALSE;
+
+//  spinlock_lock(&(g_free_memory.mm_spl));
+
+  // find adjoin block to the end of block list
+  for (i=block_list_index; i<g_shm_free_mem_mgt->max_level; i++) {
+    // set current block exist
+    shm_set_bitmap_flag(i, block_offset, MM_TRUE);
+
+    // if the offset of block is odd number, check the block of even number
+    // if exist, merge them
+    if ((block_offset % 2) == 0)
+      buddy_block_offset = block_offset + 1;
+    else
+      buddy_block_offset = block_offset - 1;
+
+    flag = shm_get_bitmap_flag(i, buddy_block_offset);
+
+    // if the block is empty, EXIT
+    if (flag == MM_FALSE)
+      break;
+
+    // merge the blocks
+    // set current and found block empty, then move to the upper block
+    shm_set_bitmap_flag(i, buddy_block_offset, MM_FALSE);
+    shm_set_bitmap_flag(i, block_offset, MM_FALSE);
+
+    // change the offset of the upper block list's
+    block_offset = block_offset / 2;
+  }
+
+//  spinlock_unlock(&(g_free_memory.mm_spl));
+
+  return TRUE;
+}
+
+/**
+ * Set the bitmap of the offset index in the block list
+ */
+void shm_set_bitmap_flag(int block_list_index, int offset, BYTE flag)
+{
+  BYTE* pBitmap = NULL;
+
+  pBitmap = g_shm_free_mem_mgt->bitmap[block_list_index].bitmap;
+
+  if (flag == MM_TRUE) {
+    // bitmap_count++ when the data is empty
+    if ((pBitmap[offset / 8] & (0x01 << (offset % 8))) == 0)
+      g_shm_free_mem_mgt->bitmap[block_list_index].bitmap_count++;
+
+    pBitmap[offset / 8] |= (0x01 << (offset % 8));
+  } else {
+    // bitmap_count-- when the data is exist
+    if ((pBitmap[offset / 8] & (0x01 << (offset % 8))) != 0)
+      g_shm_free_mem_mgt->bitmap[block_list_index].bitmap_count--;
+
+    pBitmap[offset / 8] &= ~(0x01 << (offset % 8));
+  }
+}
+
+/**
+ * Return the bitmap of the offset index in the block list
+ */
+BYTE shm_get_bitmap_flag(int block_list_index, int offset)
+{
+  BYTE* pBitmap = 0;
+
+  pBitmap = g_shm_free_mem_mgt->bitmap[block_list_index].bitmap;
+  if ((pBitmap[offset / 8] & (0x01 << (offset % 8))) != 0x00)
+    return MM_TRUE;
+
+  return MM_FALSE;
+}
+
+/**
+ * Return the block size for allocated size 
+ */
+size_t shm_get_buddy_block_size(size_t size)
+{
+  int i = 0;
+  size_t buddy_size = 0;
+
+  for(i = 0; i < 32; i++) {
+    buddy_size = PAGE_MIN_SIZE << i;
+
+    if(buddy_size > size) {
+     return(buddy_size);
+    }
+  }
+
+  return (0);
+}

--- a/kernel/shm/shm_mm.c
+++ b/kernel/shm/shm_mm.c
@@ -8,7 +8,7 @@
 #include "shm_mm.h"
 #include "console_function.h"
 
-#define DEBUG
+//#define DEBUG
 
 extern struct shm_info_s *g_shminfo;
 

--- a/kernel/shm/shm_mm.c
+++ b/kernel/shm/shm_mm.c
@@ -6,6 +6,7 @@
 #include "console.h"
 #include "thread.h"
 #include "shm_mm.h"
+#include "shm_mm_config.h"
 #include "console_function.h"
 
 //#define DEBUG

--- a/kernel/shm/shm_mm.h
+++ b/kernel/shm/shm_mm.h
@@ -1,9 +1,6 @@
-#ifndef __MM_SHM_SHM_MMH
-#define __MM_SHM_SHM_MMH
+#ifndef __SHM_MM_H__
+#define __SHM_MM_H__
 
-/****************************************************************************
- * Included Files
- ****************************************************************************/
 #include <sys/ipc.h>
 #include <sys/lock.h>
 #include <sys/shm.h>
@@ -22,10 +19,6 @@
 #define PAGE_MASK        (((~0UL) << PAGE_BITS) & ~PG_XD)
 #define PAGE_FLOOR(addr) ((addr)                   & PAGE_MASK)
 
-#define CONFIG_SHM_SHARED_MEMORY        ((QWORD) CONFIG_SHARED_MEMORY + (QWORD) IPC_START_OFFSET)
-#define CONFIG_SHM_SHARED_MEMORY_SIZE   IPC_SIZE
-#define SHM_INFO_S_VA			CONFIG_SHM_SHARED_MEMORY
-
 void shm_free_mem_init(void);
 void* shm_alloc(QWORD size);
 BOOL shm_free( void* address);
@@ -40,4 +33,4 @@ void shm_set_bitmap_flag(int block_list_index, int offset, BYTE flag);
 BYTE shm_get_bitmap_flag(int block_list_index, int offset);
 size_t shm_get_buddy_block_size(size_t size);
 
-#endif /* __MM_SHM_SHM_MMH */
+#endif /* __SHM_MM_H__ */

--- a/kernel/shm/shm_mm.h
+++ b/kernel/shm/shm_mm.h
@@ -1,0 +1,43 @@
+#ifndef __MM_SHM_SHM_MMH
+#define __MM_SHM_SHM_MMH
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <sys/ipc.h>
+#include <sys/lock.h>
+#include <sys/shm.h>
+
+#include "arch.h"
+#include "memory.h"
+#include "page.h"
+
+#define MM_TRUE		0x01
+#define MM_FALSE	0x00
+
+#define PAGE_MIN_SIZE	(4 * 1024)
+
+#define PAGE_BITS        12 
+#define PG_XD            (1L << 63)
+#define PAGE_MASK        (((~0UL) << PAGE_BITS) & ~PG_XD)
+#define PAGE_FLOOR(addr) ((addr)                   & PAGE_MASK)
+
+#define CONFIG_SHM_SHARED_MEMORY        ((QWORD) CONFIG_SHARED_MEMORY + (QWORD) IPC_START_OFFSET)
+#define CONFIG_SHM_SHARED_MEMORY_SIZE   IPC_SIZE
+#define SHM_INFO_S_VA			CONFIG_SHM_SHARED_MEMORY
+
+void shm_free_mem_init(void);
+void* shm_alloc(QWORD size);
+BOOL shm_free( void* address);
+
+int shm_bitmap_size(QWORD free_mem_size);
+int shm_alloc_buddy_block(QWORD aligned_size);
+QWORD shm_align_buddy_block(QWORD size);
+int shm_block_list_index(QWORD aligned_size);
+int shm_find_free_block(int block_list_index);
+BOOL shm_free_buddy_block(int block_list_index, int block_offset);
+void shm_set_bitmap_flag(int block_list_index, int offset, BYTE flag);
+BYTE shm_get_bitmap_flag(int block_list_index, int offset);
+size_t shm_get_buddy_block_size(size_t size);
+
+#endif /* __MM_SHM_SHM_MMH */

--- a/kernel/shm/shm_mm_config.h
+++ b/kernel/shm/shm_mm_config.h
@@ -1,0 +1,11 @@
+#ifndef __SHM_MM_CONFIG_H__
+#define __SHM_MM_CONFIG_H__
+
+#include "arch.h"
+#include "page.h"
+
+#define CONFIG_SHM_SHARED_MEMORY        ((QWORD) CONFIG_SHARED_MEMORY + (QWORD) IPC_START_OFFSET)
+#define CONFIG_SHM_SHARED_MEMORY_SIZE   IPC_SIZE
+#define SHM_INFO_S_VA			CONFIG_SHM_SHARED_MEMORY
+
+#endif /* __SHM_MM_CONFIG_H__ */

--- a/kernel/shm/shmat.c
+++ b/kernel/shm/shmat.c
@@ -1,0 +1,175 @@
+/****************************************************************************
+ * mm/shm/shmat.c
+ *
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include "console.h"
+#include "console_function.h"
+#include "shm.h"
+#include "thread.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: shmat
+ *
+ * Description:
+ *   The shmat() function attaches the shared memory segment associated with
+ *   the shared memory identifier specified by shmid to the address space of
+ *   the calling process. The segment is attached at the address specified
+ *   by one of the following criteria:
+ *
+ *     - If shmaddr is a null pointer, the segment is attached at the first
+ *       available address as selected by the system.
+ *     - If shmaddr is not a null pointer and (shmflg & SHM_RND) is non-
+ *       zero, the segment is attached at the address given by
+ *       (shmaddr - ((uintptr_t)shmaddr % SHMLBA)).
+ *     - If shmaddr is not a null pointer and (shmflg & SHM_RND) is 0, the
+ *       segment is attached at the address given by shmaddr.
+ *     - The segment is attached for reading if (shmflg & SHM_RDONLY) is
+ *       non-zero and the calling process has read permission; otherwise, if
+ *       it is 0 and the calling process has read and write permission, the
+ *       segment is attached for reading and writing.
+ *
+ * Input Parameters:
+ *   shmid  - Shared memory identifier
+ *   smaddr - Determines mapping of the shared memory region
+ *   shmflg - See SHM_* definitions in include/sys/shm.h.  Only SHM_RDONLY
+ *            and SHM_RND are supported.
+ *
+ * Returned Value:
+ *   Upon successful completion, shmat() will increment the value of
+ *   shm_nattch in the data structure associated with the shared memory ID
+ *   of the attached shared memory segment and return the segment's start
+ *   address.
+ *
+ *   Otherwise, the shared memory segment will not be attached, shmat() will
+ *   return -1, and errno will be set to indicate the error.
+ *
+ *     - EACCES
+ *       Operation permission is denied to the calling process
+ *     - EINVAL
+ *       The value of shmid is not a valid shared memory identifier, the
+ *       shmaddr is not a null pointer, and the value of
+ *       (shmaddr -((uintptr_t)shmaddr % SHMLBA)) is an illegal address for
+ *       attaching shared memory; or the shmaddr is not a null pointer,
+ *       (shmflg & SHM_RND) is 0, and the value of shmaddr is an illegal
+ *       address for attaching shared memory.
+ *     - EMFILE
+ *       The number of shared memory segments attached to the calling
+ *       process would exceed the system-imposed limit.
+ *     - ENOMEM
+ *       The available data space is not large enough to accommodate the
+ *       shared memory segment.
+ *
+ ****************************************************************************/
+
+void *shmat(int shmid, const void *shmaddr, int shmflg)
+{
+  struct shm_region_s *region;
+  unsigned char *vaddr;
+
+  g_shminfo = (struct shm_info_s *) SHM_INFO_S_VA;
+
+#ifdef DEBUG
+  cs_printf("shmat(): shmid = %d, shmaddr = %q, shmflg = %d\n", shmid, shmaddr, shmflg);
+#endif
+
+  //DEBUGASSERT(shmid >= 0 && shmid < CONFIG_ARCH_SHM_MAXREGIONS);
+  if(shmid < 0 || shmid >= CONFIG_ARCH_SHM_MAXREGIONS) {
+    lk_print("shmat(): Invalid shmid %d\n", shmid);
+    return (void *) NULL;
+  }
+
+  /* Get the region associated with the shmid */
+  region =  &g_shminfo->si_region[shmid];
+
+  //DEBUGASSERT((region->sr_flags & SRFLAG_INUSE) != 0);
+  if((region->sr_flags & SRFLAG_INUSE) == 0) {
+    lk_print("shmat(): Invalid shmid %d\n", shmid);
+    return (void *) NULL;
+  }
+
+  /* Get exclusive access to the region data structure */
+  spinlock_lock(&region->sr_lock);
+
+  /* Set aside a virtual address space to span this physical region */
+  vaddr = (unsigned char *) region->sr_data;
+  if(vaddr == NULL)
+  {
+    lk_print("shmat(): failed to get shared address.\n");
+    goto errout_with_lock;
+  }
+
+  /* Increment the count of processes attached to this region */
+  region->sr_ds.shm_nattch++;
+
+  /* Save the process ID of the the last operation */
+  region->sr_ds.shm_lpid = sys_getpid();
+
+  /* Save the time of the last shmat() */
+  //TODO region->sr_ds.shm_atime = time(NULL);
+
+  /* Release our lock on the entry */
+  spinlock_unlock(&region->sr_lock);
+
+  return (void *)vaddr;
+
+errout_with_lock:
+  /* Release our lock on the entry */
+  spinlock_unlock(&region->sr_lock);
+
+  return (void *) NULL;
+}
+

--- a/kernel/shm/shmat.c
+++ b/kernel/shm/shmat.c
@@ -39,6 +39,7 @@
 #include "console.h"
 #include "console_function.h"
 #include "shm.h"
+#include "shm_mm_config.h"
 #include "thread.h"
 
 /****************************************************************************

--- a/kernel/shm/shmctl.c
+++ b/kernel/shm/shmctl.c
@@ -42,6 +42,7 @@
 
 #include "console.h"
 #include "shm.h"
+#include "shm_mm_config.h"
 #include "thread.h"
 #include "utility.h"
 

--- a/kernel/shm/shmctl.c
+++ b/kernel/shm/shmctl.c
@@ -1,0 +1,276 @@
+/****************************************************************************
+ * mm/shm/shmctl.c
+ *
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <errno.h>
+#include <sys/lock.h>
+#include <sys/shm.h>
+
+#include "console.h"
+#include "shm.h"
+#include "thread.h"
+#include "utility.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: shmctl
+ *
+ * Description:
+ *   The shmctl() function provides a variety of shared memory control
+ *   operations as specified by cmd. The following values for cmd are
+ *   available:
+ *
+ *     - IPC_STAT
+ *       Place the current value of each member of the shmid_ds data
+ *       structure associated with shmid into the structure pointed to by
+ *       buf.
+ *     - IPC_SET
+ *       Set the value of the shm_perm.mode member of the shmid_ds data
+ *       structure associated with shmid to the corresponding value found
+ *       in the structure pointed to by buf.
+ *     - IPC_RMID
+ *       Remove the shared memory identifier specified by shmid from the
+ *       system and destroy the shared memory segment and shmid_ds data
+ *       structure associated with it.
+ *
+ * Input Parameters:
+ *   shmid - Shared memory identifier
+ *   cmd - shmctl() command
+ *   buf - Data associated with the shmctl() command
+ *
+ * Returned Value:
+ *   Upon successful completion, shmctl() will return 0; otherwise, it will
+ *   return -1 and set errno to indicate the error.
+ *
+ *     - EACCES
+ *       The argument cmd is equal to IPC_STAT and the calling process does
+ *       not have read permission.
+ *     - EINVAL
+ *       The value of shmid is not a valid shared memory identifier, or the
+ *       value of cmd is not a valid command.
+ *     - EPERM
+ *       The argument cmd is equal to IPC_RMID or IPC_SET and the effective
+ *       user ID of the calling process is not equal to that of a process
+ *       with appropriate privileges and it is not equal to the value of
+ *       shm_perm.cuid or shm_perm.uid in the data structure associated with
+ *       shmid.
+ *     - EOVERFLOW
+ *       The cmd argument is IPC_STAT and the gid or uid value is too large
+ *       to be stored in the structure pointed to by the buf argument.
+ *
+ * POSIX Deviations:
+ *     - IPC_SET.  Does not set the the shm_perm.uid or shm_perm.gid
+ *       members of the shmid_ds data structure associated with shmid
+ *       because user and group IDs are not yet supported by NuttX
+ *     - IPC_SET.  Does not restrict the operation to processes with
+ *       appropriate privileges or matching user IDs in shmid_ds data
+ *       structure associated with shmid.  Again because user IDs and
+ *       user/group privileges are are not yet supported by NuttX
+ *     - IPC_RMID.  Does not restrict the operation to processes with
+ *       appropriate privileges or matching user IDs in shmid_ds data
+ *       structure associated with shmid.  Again because user IDs and
+ *       user/group privileges are are not yet supported by NuttX
+ *
+ ****************************************************************************/
+
+int shmctl(int shmid, int cmd, struct shmid_ds *buf)
+{
+  struct shm_region_s *region;
+
+  g_shminfo = (struct shm_info_s *) SHM_INFO_S_VA;
+
+  //DEBUGASSERT(shmid >= 0 && shmid < CONFIG_ARCH_SHM_MAXREGIONS);
+  if(shmid < 0 || shmid >= CONFIG_ARCH_SHM_MAXREGIONS) {
+    lk_print("shmctl() - Invalid shmid %d\n", shmid);
+    return (-1);
+  }
+
+  /* Get the region associated with the shmid */
+  region =  &g_shminfo->si_region[shmid];
+
+  //DEBUGASSERT((region->sr_flags & SRFLAG_INUSE) != 0);
+  if((region->sr_flags & SRFLAG_INUSE) == 0) {
+    lk_print("shmctl() - Invalid shmid %d\n", shmid);
+    return (-1);
+  }
+
+  /* Get exclusive access to the region data structure */
+  spinlock_lock(&region->sr_lock);
+
+  /* Handle the request according to the received cmd */
+  switch (cmd)
+  {
+    case IPC_STAT:
+    {
+      /* Place the current value of each member of the shmid_ds data
+       * structure associated with shmid into the structure pointed to
+       * by buf.
+       */
+
+      //DEBUGASSERT(buf);
+      if(buf == NULL) {
+        goto errout_with_semaphore;
+      }
+      lk_memcpy(buf, &region->sr_ds, sizeof(struct shmid_ds));
+    }
+    break;
+
+    case IPC_SET:
+    {
+      /* Set the value of the shm_perm.mode member of the shmid_ds
+       * data structure associated with shmid to the corresponding
+       * value found in the structure pointed to by buf.
+       */
+
+      region->sr_ds.shm_perm.mode = buf->shm_perm.mode;
+    }
+    break;
+
+    case IPC_RMID:
+    {
+      /* Are any processes attached to the region? */
+
+      if (region->sr_ds.shm_nattch > 0)
+      {
+        /* Yes.. just set the UNLINKED flag.  The region will be removed when there are no longer any processes attached to it.
+               */
+
+        region->sr_flags |= SRFLAG_UNLINKED;
+      }
+      else
+      {
+        /* No.. free the entry now */
+
+        shm_destroy(shmid);
+
+        /* Don't try anything further on the deleted region */
+
+        //return OK;
+        return (0);
+      }
+    }
+    break;
+
+    default:
+      lk_print("shmctl() - Unrecognized command: %d\n", cmd);
+      //ret = -EINVAL;
+      goto errout_with_semaphore;
+  }
+
+  /* Save the process ID of the the last operation */
+  region = &g_shminfo->si_region[shmid];
+  region->sr_ds.shm_lpid = sys_getpid();
+
+  /* Save the time of the last shmctl() */
+  //TODO region->sr_ds.shm_ctime = time(NULL);
+
+  /* Release our lock on the entry */
+  spinlock_unlock(&region->sr_lock);
+
+  //return OK;
+  return (0);
+
+errout_with_semaphore:
+
+  /* Release our lock on the entry */
+  spinlock_unlock(&region->sr_lock);
+
+  //return ERROR;
+  return (-1);
+}
+
+/****************************************************************************
+ * Name: shm_destroy
+ *
+ * Description:
+ *   Destroy a memory region.  This function is called:
+ *
+ *   - On certain conditions when shmget() is not successful in instantiating
+ *     the full memory region and we need to clean up and free a table entry.
+ *   - When shmctl() is called with cmd == IPC_RMID and there are no
+ *     processes attached to the memory region.
+ *   - When shmdt() is called after the last process detaches from memory
+ *     region after it was previously marked for deletion by shmctl().
+ *
+ * Input Parameters:
+ *   shmid - Shared memory identifier
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumption:
+ *   The caller holds either the region table semaphore or else the
+ *   semaphore on the particular entry being deleted.
+ *
+ ****************************************************************************/
+
+void shm_destroy(int shmid)
+{
+
+  struct shm_region_s *region;
+
+  g_shminfo = (struct shm_info_s *) SHM_INFO_S_VA;
+
+  region =  &g_shminfo->si_region[shmid];
+
+  // free shred memory
+  if(region->sr_data != NULL)
+    shm_free(region->sr_data);
+
+  /* Reset the region entry to its initial state */
+  lk_memset(region, 0, sizeof(struct shm_region_s));
+}
+

--- a/kernel/shm/shmdt.c
+++ b/kernel/shm/shmdt.c
@@ -40,6 +40,7 @@
 #include "console_function.h"
 #include "errno.h"
 #include "shm.h"
+#include "shm_mm_config.h"
 #include "thread.h"
 
 /****************************************************************************

--- a/kernel/shm/shmdt.c
+++ b/kernel/shm/shmdt.c
@@ -1,0 +1,169 @@
+/****************************************************************************
+ * mm/shm/shmdt.c
+ *
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include "console.h"
+#include "console_function.h"
+#include "errno.h"
+#include "shm.h"
+#include "thread.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: shmdt
+ *
+ * Description:
+ *   The shmdt() function detaches the shared memory segment located at the
+ *   address specified by shmaddr from the address space of the calling
+ *   process.
+ *
+ * Input Parameters:
+ *   shmid - Shared memory identifier
+ *
+ * Returned Value:
+ *   Upon successful completion, shmdt() will decrement the value of
+ *   shm_nattch in the data structure associated with the shared memory ID
+ *   of the attached shared memory segment and return 0.
+ *
+ *   Otherwise, the shared memory segment will not be detached, shmdt()
+ &   will return -1, and errno will be set to indicate the error.
+ *
+ *   - EINVAL
+ *     The value of shmaddr is not the data segment start address of a
+ *     shared memory segment.
+ *
+ ****************************************************************************/
+
+int shmdt(const void *shmaddr)
+{
+  struct shm_region_s *region;
+  int shmid;
+
+  /* Perform the reverse lookup to get the shmid corresponding to this
+   * shmaddr.
+   */
+  g_shminfo = (struct shm_info_s *) SHM_INFO_S_VA;
+
+  for (shmid = 0; shmid < CONFIG_ARCH_SHM_MAXREGIONS; shmid++)
+  {
+    region =  &g_shminfo->si_region[shmid];
+    if(shmaddr == region->sr_data)
+      break;
+  }
+
+  if (shmid >= CONFIG_ARCH_SHM_MAXREGIONS)
+    {
+      lk_print("shmdt(): No region matching this virtual address: %q\n", shmaddr);
+      goto errout_with_errno;
+    }
+
+  /* Get the region associated with the shmid */
+  region =  &g_shminfo->si_region[shmid];
+
+  //DEBUGASSERT((region->sr_flags & SRFLAG_INUSE) != 0);
+  if((region->sr_flags & SRFLAG_INUSE) == 0) {
+    lk_print("shmdt(): Not in use for this virtual address: %q\n", shmaddr);
+    return (-1);
+  }
+
+  /* Get exclusive access to the region data structure */
+  spinlock_lock(&region->sr_lock);
+
+  //DEBUGASSERT(region->sr_ds.shm_nattch > 0);
+  if(region->sr_ds.shm_nattch <= 0) {
+    lk_print("shmdt(): Not attached to this virtual address %q\n", shmaddr);
+    spinlock_unlock(&region->sr_lock);
+    return (-1);
+  }
+
+
+  if (region->sr_ds.shm_nattch <= 1)
+  {
+    region->sr_ds.shm_nattch = 0;
+    if ((region->sr_flags & SRFLAG_UNLINKED) != 0)
+    {
+      shm_destroy(shmid); // will be unlocked with shm_destroy()
+      //return OK;
+      return (0);
+    }
+  }
+  else
+  {
+    /* Just decrement the number of processes attached to the shared
+     * memory region.
+     */
+
+    region->sr_ds.shm_nattch--;
+  }
+
+  /* Save the process ID of the the last operation */
+
+  region->sr_ds.shm_lpid = sys_getpid();
+
+  /* Save the time of the last shmdt() */
+  //TODO region->sr_ds.shm_dtime = time(NULL);
+
+  /* Release our lock on the entry */
+  spinlock_unlock(&region->sr_lock);
+
+  //return OK;
+  return (0);
+
+errout_with_errno:
+  //return ERROR;
+  return (-1);
+}
+

--- a/kernel/shm/shmget.c
+++ b/kernel/shm/shmget.c
@@ -39,6 +39,7 @@
 #include "console.h"
 #include "console_function.h"
 #include "shm.h"
+#include "shm_mm_config.h"
 #include "thread.h"
 #include "utility.h"
 

--- a/kernel/shm/shmget.c
+++ b/kernel/shm/shmget.c
@@ -1,0 +1,484 @@
+/****************************************************************************
+ * mm/shm/shmget.c
+ *
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include "console.h"
+#include "console_function.h"
+#include "shm.h"
+#include "thread.h"
+#include "utility.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: shm_find
+ *
+ * Description:
+ *   Find the shared memory region with matching key
+ *
+ * Input parameters:
+ *   key - The value that uniquely identifies a shared memory region.
+ *
+ * Returned value:
+ *   On success, an index in the range of 0 to CONFIG_ARCH_SHM_MAXREGIONS-1
+ *   is returned to identify the matching region; -ENOENT is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static int shm_find(key_t key)
+{
+  int i;
+
+#ifdef DEBUG
+  cs_printf("shm_find(): key = %d\n", key);
+#endif
+  for (i = 0; i < CONFIG_ARCH_SHM_MAXREGIONS; i++)
+  {
+     if (g_shminfo->si_region[i].sr_key == key)
+     {
+        return i;
+     }
+  }
+
+  return (-1);
+}
+
+/****************************************************************************
+ * Name: shm_reserve
+ *
+ * Description:
+ *   Allocate an unused shared memory region.  That is one with a key of -1
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned value:
+ *   On success, an index in the range of 0 to CONFIG_ARCH_SHM_MAXREGIONS-1
+ *   is returned to identify the matching region; -ENOSPC is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static int shm_reserve(key_t key, int shmflg)
+{
+  struct shm_region_s *region;
+  int i;
+
+#ifdef DEBUG
+  cs_printf("shm_reserve(): key = %d, shmflg = %d\n", key, shmflg);
+#endif
+  for (i = 0; i < CONFIG_ARCH_SHM_MAXREGIONS; i++)
+    {
+      /* Is this region in use? */
+
+      region = &g_shminfo->si_region[i];
+      if (region->sr_flags == SRFLAG_AVAILABLE)
+      {
+        /* No... reserve it for the caller now */
+
+         //lk_memset(region, 0, sizeof(struct shm_region_s));
+         region->sr_key   = key;
+         region->sr_flags = SRFLAG_INUSE;
+ 
+         spinlock_init(&region->sr_lock);
+ 
+         /* Set the low-order nine bits of shm_perm.mode to the low-order
+          * nine bits of shmflg.
+          */
+ 
+         region->sr_ds.shm_perm.mode = shmflg & IPC_MODE;
+ 
+         /* The value of shm_segsz is left equal to zero for now because no
+          * memory has yet been allocated.
+          *
+          * The values of shm_lpid, shm_nattch, shm_atime, and shm_dtime are
+          * set equal to 0.
+          */
+ 
+         /* The value of shm_ctime is set equal to the current time. */
+ 
+         //TODO: region->sr_ds.shm_ctime = time(NULL);
+         return i;
+      }
+    }
+
+  return -ENOSPC;
+}
+
+/****************************************************************************
+ * Name: shm_extend
+ *
+ * Description:
+ *   Extend the size of a memory regions by allocating physical pages as
+ *   necessary
+ *
+ * Input parameters:
+ *   shmid - The index of the region of interest in the shared memory region
+ *     table.
+ *   size - The new size of the region.
+ *
+ * Returned value:
+ *   Zero is returned on success; -ENOMEM is returned on failure.
+ *   (Should a different error be returned if the region is just too big?)
+ *
+ ****************************************************************************/
+
+int shm_extend(int shmid, size_t size)
+{
+  struct shm_region_s *region =  NULL;
+
+#ifdef DEBUG
+  cs_printf("shm_extend(): shmid = %d, size = %d\n", shmid, size);
+#endif
+
+  region =  &g_shminfo->si_region[shmid];
+
+  /* Set the new region size and return success */
+
+  if(size > region->sr_ds.shm_segsz) {
+    // check page count 
+    size_t allocated_block_size = shm_get_buddy_block_size(region->sr_ds.shm_segsz); 
+    if(size > allocated_block_size) {
+    //if((int) (size / PAGE_MIN_SIZE) != (int) (region->sr_ds.shm_segsz / PAGE_MIN_SIZE)) {
+      return -ENOMEM;
+    }
+    else {
+      lk_memset(&(region->sr_data[region->sr_ds.shm_segsz]), 0, (size - region->sr_ds.shm_segsz));
+      region->sr_ds.shm_segsz = size;
+    }
+  }
+
+  //return OK;
+  return (1);
+}
+
+/****************************************************************************
+ * Name: shm_create
+ *
+ * Description:
+ *   Create the shared memory region.
+ *
+ * Input parameters:
+ *   key     - The key that is used to access the unique shared memory
+ *             identifier.
+ *   size    - The shared memory region that is created will be at least
+ *             this size in bytes.
+ *   shmflgs - See IPC_* definitions in sys/ipc.h.  Only the values
+ *             IPC_PRIVATE or IPC_CREAT are supported.
+ *
+ * Returned value:
+ *   Zero is returned on success;  A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static int shm_create(key_t key, size_t size, int shmflg)
+{
+  struct shm_region_s *region = NULL;
+  int shmid = -1;
+  int ret = -1;
+
+#ifdef DEBUG
+  cs_printf("shm_created(): key = %d, size = %d, shmflg = %d\n", key, size, shmflg);
+#endif
+
+  /* Reserve the shared memory region */
+  ret = shm_reserve(key, shmflg);
+
+  if (ret < 0)
+  {
+    lk_print("shm_create(): shm_reserve() failed: %d\n", ret);
+    return ret;
+  }
+
+  /* Save the shared memory ID */
+  shmid = ret;
+
+  /* Then allocate the physical memory (by extending it from the initial
+   * size of zero).
+   */
+
+  region = &g_shminfo->si_region[shmid];
+
+  region->sr_data = (unsigned char *) shm_alloc(size);
+#ifdef DEBUG
+  cs_printf("shm_create(): region->sr_data addr = %q\n", region->sr_data);
+#endif
+
+  if(region->sr_data == NULL) {
+    lk_print("shm_create(): shm memory allocation failed.\n");
+
+    shm_destroy(shmid);
+    return -ENOMEM;
+  }
+
+  /* Save the size of the request memory size */
+  region->sr_ds.shm_segsz = size;
+
+  /* Save the process ID of the creator */
+  region->sr_ds.shm_cpid = sys_getpid();
+
+  /* Return the shared memory ID */
+
+  return shmid;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: shmget
+ *
+ * Description:
+ *   The shmget() function will return the shared memory identifier
+ *   associated with key.
+ *
+ *   A shared memory identifier, associated data structure, and shared
+ *   memory segment of at least size bytes is created for key if one of the
+ *   following is true:
+ *
+ *     - The argument key is equal to IPC_PRIVATE.
+ *     - The argument key does not already have a shared memory identifier
+ *       associated with it and (shmflg & IPC_CREAT) is non-zero.
+ *
+ *   Upon creation, the data structure associated with the new shared memory
+ *   identifier will be initialized as follows:
+ *
+ *     - The low-order nine bits of shm_perm.mode are set equal to the low-
+ *       order nine bits of shmflg.
+ *     - The value of shm_segsz is set equal to the value of size.
+ *     - The values of shm_lpid, shm_nattch, shm_atime, and shm_dtime are
+ *       set equal to 0.
+ *     - The value of shm_ctime is set equal to the current time.
+ *
+ *   When the shared memory segment is created, it will be initialized with
+ *   all zero values.
+ *
+ * Input Parameters:
+ *   key     - The key that is used to access the unique shared memory
+ *             identifier.
+ *   size    - The shared memory region that is created will be at least
+ *             this size in bytes.
+ *   shmflgs - See IPC_* definitions in sys/ipc.h.  Only the values
+ *             IPC_PRIVATE or IPC_CREAT are supported.
+ *
+ * Returned Value:
+ *   Upon successful completion, shmget() will return a non-negative
+ *   integer, namely a shared memory identifier; otherwise, it will return
+ *   -1 and set errno to indicate the error.
+ *
+ *     - EACCES
+ *       A shared memory identifier exists for key but operation permission
+ *       as specified by the low-order nine bits of shmflg would not be
+ *       granted.
+ *     - EEXIST
+ *       A shared memory identifier exists for the argument key but
+ *      (shmflg & IPC_CREAT) && (shmflg & IPC_EXCL) are non-zero.
+ *     - EINVAL
+ *       A shared memory segment is to be created and the value of size is
+ *       less than the system-imposed minimum or greater than the system-
+ *       imposed maximum.
+ *     - EINVAL
+ *       No shared memory segment is to be created and a shared memory
+ *       segment exists for key but the size of the segment associated with
+ *       it is less than size and size is not 0.
+ *     - ENOENT
+ *       A shared memory identifier does not exist for the argument key and
+ *       (shmflg & IPC_CREAT) is 0.
+ *     - ENOMEM
+ *       A shared memory identifier and associated shared memory segment
+ *       will be created, but the amount of available physical memory is
+ *       not sufficient to fill the request.
+ *     - ENOSPC
+ *       A shared memory identifier is to be created, but the system-imposed
+ *       limit on the maximum number of allowed shared memory identifiers
+ *       system-wide would be exceeded.
+ *
+ * POSIX Deviations:
+ *     - The values of shm_perm.cuid, shm_perm.uid, shm_perm.cgid, and
+ *       shm_perm.gid should be set equal to the effective user ID and
+ *       effective group ID, respectively, of the calling process.
+ *       The NuttX ipc_perm structure, however, does not support these
+ *       fields because user and group IDs are not yet supported by NuttX.
+ *
+ ****************************************************************************/
+
+int shmget(key_t key, size_t size, int shmflg)
+{
+  struct shm_region_s *region;
+  int shmid = -1;
+  int ret;
+
+  /* Check for the special case where the caller doesn't really want shared
+   * memory (they why do they bother to call us?)
+   */
+  
+  g_shminfo = (struct shm_info_s *) SHM_INFO_S_VA;
+
+#ifdef DEBUG
+  cs_printf("shmget(): key = %d, size = %d, shmflg = %d\n", key, size, shmflg);
+  cs_printf("shmget(): shm_info addr = %q\n", g_shminfo);
+#endif
+
+  if (key == IPC_PRIVATE)
+  {
+    /* Not yet implemented */
+
+    ret = -ENOSYS;
+    goto errout;
+  }
+
+
+  /* Get exclusive access to the global list of shared memory regions */
+#ifdef DEBUG
+  cs_printf("shmget(): try lock\n");
+#endif
+  spinlock_lock(&g_shminfo->si_lock);
+#ifdef DEBUG
+  cs_printf("shmget(): lock success\n");
+#endif
+
+  if(g_shminfo->shm_init_flag == 0) {
+    shm_initialize();
+    shm_free_mem_init();
+    g_shminfo->shm_init_flag = 1;
+  }
+
+  /* Find the requested memory region */
+  ret = shm_find(key);
+
+  if (ret < 0)
+  {
+    /* The memory region does not exist.. create it if IPC_CREAT is
+     * included in the shmflags.
+     */
+
+    if ((shmflg & IPC_CREAT) != 0)
+    {
+      /* Create the memory region */
+      ret = shm_create(key, size, shmflg);
+      if (ret < 0)
+      {
+        //shmdbg("shm_create failed: %d\n", ret);
+        lk_print("shmget(): shm_create() failed: %d\n", ret);
+        goto errout_with_lock;
+      }
+
+      /* Return the shared memory ID */
+      shmid = ret;
+    }
+    else
+    {
+      /* Fail with ENOENT */
+      goto errout_with_lock;
+    }
+  }
+  /* The region exists */
+  else
+  {
+    /* Remember the shared memory ID */
+
+    shmid = ret;
+
+    /* Is the region big enough for the request? */
+
+    region = &g_shminfo->si_region[shmid];
+    if (region->sr_ds.shm_segsz < size)
+    {
+      /* We we asked to create the region?  If so we can just
+       * extend it.
+       *
+       * REVISIT: We should check the mode bits of the regions
+       * first
+       */
+
+      if ((shmflg & IPC_CREAT) != 0)
+      {
+        /* Extend the region */
+        ret = shm_extend(shmid, size);
+        if (ret < 0)
+        {
+          lk_print("shmget(); shm_extend() failed: %d\n", ret);
+          goto errout_with_lock;
+        }
+      }
+      else
+      {
+        /* Fail with EINVAL */
+        ret = -EINVAL;
+        goto errout_with_lock;
+      }
+    }
+
+    /* The region is already big enough or else we successfully
+     * extended the size of the region.  If the region was previously
+     * deleted, but waiting for processes to detach from the region,
+     * then it is no longer deleted.
+     */
+
+    region->sr_flags = SRFLAG_INUSE;
+  }
+
+  /* Release our lock on the shared memory region list */
+  spinlock_unlock(&g_shminfo->si_lock);
+
+  return shmid;
+
+errout_with_lock:
+  /* Release our lock on the shared memory region list */
+  spinlock_unlock(&g_shminfo->si_lock);
+
+errout:
+  return (-1);
+}
+

--- a/kernel/systemcall.c
+++ b/kernel/systemcall.c
@@ -21,6 +21,7 @@
 #include "offload_fio.h"
 #include "offload_network.h"
 #include "console_function.h"
+#include "shm/shm.h"
 
 static spinlock_t a_lock;
 /**
@@ -393,6 +394,18 @@ QWORD process_systemcall(QWORD param1, QWORD param2, QWORD param3,
     break;
   case SYSCALL_sys3_rewinddir:
     sys3_off_rewinddir((DIR *)param1);
+    break;
+  case SYSCALL_sys_shmget:
+    ret_code = (QWORD) shmget((key_t) param1, (size_t) param2, (int) param3);
+    break;
+  case SYSCALL_sys_shmat:
+    ret_code = (QWORD) shmat((int) param1, (const void *) param2, (int) param3);
+    break;
+  case SYSCALL_sys_shmdt:
+    ret_code = (QWORD) shmdt((const void *) param1);
+    break;
+  case SYSCALL_sys_shmctl:
+    ret_code = (QWORD) shmctl((int) param1, (int) param2, (struct shmid_ds *) param3);
     break;
   default:
     printk("Invalid system calls");

--- a/kernel/systemcalllist.h
+++ b/kernel/systemcalllist.h
@@ -44,6 +44,10 @@
 #define SYSCALL_sys_brk                 532
 #define SYSCALL_sys_chdir               533
 #define SYSCALL_sys_link                534
+#define SYSCALL_sys_shmget              535
+#define SYSCALL_sys_shmat               536
+#define SYSCALL_sys_shmdt               537
+#define SYSCALL_sys_shmctl              538
 
 
 #define SYSCALL_do_exit                 550

--- a/library/syscall.c
+++ b/library/syscall.c
@@ -43,6 +43,10 @@ _syscall1(int, sys_unlink, const char *, path);
 _syscall2(int, sys_stat, const char*, pathname, struct stat*, buf);
 _syscall1(int, sys_brk, void *, addr);
 _syscall1(int, sys_chdir, const char*, path);
+_syscall3(int, sys_shmget, key_t, key, size_t, size, int, shmflg);
+_syscall3(void*, sys_shmat, int, shmid, const void *, shmaddr, int, shmflg);
+_syscall1(int, sys_shmdt, const void *, shmaddr);
+_syscall3(int, sys_shmctl, int, shmid, int, cmd, struct shmid_ds *, buf);
 
 _syscall1(void, do_exit, int, arg);
 _syscall0(int, block_current_task);

--- a/library/syscall.h
+++ b/library/syscall.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
+#include <sys/shm.h>
 
 #include "systemcalllist.h"
 #include "az_types.h"
@@ -166,6 +167,11 @@ int sys_unlink(const char *path);
 int sys_stat(const char *pathname, struct stat *buf);
 int sys_brk(void *addr);
 int sys_chdir(const char *path);
+
+int sys_shmget(key_t key, size_t size, int shmflg);
+void* sys_shmat(int shmid, const void *shmaddr, int shmflg);
+int sys_shmdt(const void *shmaddr);
+int sys_shmctl(int shmid, int cmd, struct shmid_ds *buf);
 
 // Network offloading related systemcalls
 int sys_gethostname(char *name, size_t len);


### PR DESCRIPTION
#135 
shmget(), shmat(), shmdt(), shmctl() in kernel/shm

sample app is located at application/shm
shared memory is allocated by buddy algorithm.
shared memory area is as following. (cf, include/knl/arch.h)
#define IPC_START_OFFSET (APP_START_OFFSET + APP_SIZE)
#define IPC_SIZE ((unsigned long) (512<<20)) // 512MB
